### PR TITLE
🧪 [testing improvement] Add missing tests for isValidUrl options and edge cases

### DIFF
--- a/.jules/testing.md
+++ b/.jules/testing.md
@@ -1,0 +1,5 @@
+## isValidUrl Missing Coverage
+- **Task:** Added missing coverage for isValidUrl utility function options.
+- **Gap:** Found missing specific tests testing optional flags for `isValidUrl` and some edge cases (dangerous patterns/control characters).
+- **Coverage:** Replaced direct checks for isValidUrl and replaced with a full suite testing standard protocols, options parameter checking logic (allowMailto/allowTel/allowSms), relative paths checking logic, dangerous patterns, and control characters checking logic.
+- **Result:** Increased testing and function safety checking against regressions over options parsing and dangerous URL injection.

--- a/tests/security.spec.ts
+++ b/tests/security.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { safeJson, sanitizeInput, sanitizeUrl, isValidUrl } from "../src/utils/security";
 
 test("safeJson handles undefined or function inputs safely", () => {
@@ -60,4 +60,63 @@ test("sanitizeUrl blocks obfuscated javascript URLs", () => {
 
   expect(isValidUrl("javascript&#58;alert(1)")).toBe(false);
   expect(isValidUrl(" jav&#x0a;ascript:alert(1)")).toBe(false);
+});
+
+describe("isValidUrl", () => {
+  test("allows standard web protocols", () => {
+    expect(isValidUrl("http://example.com")).toBe(true);
+    expect(isValidUrl("https://example.com")).toBe(true);
+  });
+
+  test("handles optional protocols based on options", () => {
+    // By default, these should be false
+    expect(isValidUrl("mailto:test@example.com")).toBe(false);
+    expect(isValidUrl("tel:+1234567890")).toBe(false);
+    expect(isValidUrl("sms:+1234567890")).toBe(false);
+
+    // With options enabled
+    expect(isValidUrl("mailto:test@example.com", { allowMailto: true })).toBe(true);
+    expect(isValidUrl("tel:+1234567890", { allowTel: true })).toBe(true);
+    expect(isValidUrl("sms:+1234567890", { allowSms: true })).toBe(true);
+  });
+
+  test("allows relative paths, fragments, and queries", () => {
+    expect(isValidUrl("/about")).toBe(true);
+    expect(isValidUrl("/")).toBe(true);
+    expect(isValidUrl("#section")).toBe(true);
+    expect(isValidUrl("?query=param")).toBe(true);
+  });
+
+  test("rejects dangerous or malformed URLs", () => {
+    expect(isValidUrl("javascript:alert(1)")).toBe(false);
+    expect(isValidUrl("vbscript:msgbox(1)")).toBe(false);
+    expect(isValidUrl("data:text/html,<script>alert(1)</script>")).toBe(false);
+    expect(isValidUrl("ftp://example.com")).toBe(false); // Only http/https are in default allowlist
+  });
+
+  test("rejects protocol-relative URLs", () => {
+    expect(isValidUrl("//example.com")).toBe(false);
+  });
+
+  test("rejects URLs with control characters or dangerous patterns", () => {
+    expect(isValidUrl("https://example.com/test\n")).toBe(false);
+    expect(isValidUrl("https://example.com/test\t")).toBe(false);
+    expect(isValidUrl("https://example.com/test\r")).toBe(false);
+    expect(isValidUrl("https://example.com/<script>")).toBe(false);
+    expect(isValidUrl("https://example.com/test\"")).toBe(false);
+    expect(isValidUrl("https://example.com/test'")).toBe(false);
+    expect(isValidUrl("https://example.com/test`")).toBe(false);
+  });
+
+  test("handles invalid inputs gracefully", () => {
+    expect(isValidUrl("")).toBe(false);
+    // @ts-expect-error - testing invalid type
+    expect(isValidUrl(null)).toBe(false);
+    // @ts-expect-error - testing invalid type
+    expect(isValidUrl(undefined)).toBe(false);
+    // @ts-expect-error - testing invalid type
+    expect(isValidUrl(123)).toBe(false);
+    // @ts-expect-error - testing invalid type
+    expect(isValidUrl({})).toBe(false);
+  });
 });


### PR DESCRIPTION
🎯 **What:** The gap addressed is that isValidUrl did not have direct functional testing, particularly surrounding options behavior (allowMailto/allowTel/allowSms) and specific edge cases like dangerous injections.

📊 **Coverage:** Scenarios tested include standard protocols, options parameter testing (allowMailto/allowTel/allowSms toggles), relative pathing options, malformed/dangerous URLs with obfuscated js strings, and checking control characters.

✨ **Result:** A significant improvement in test coverage over security functions ensuring isValidUrl doesn't inadvertently leak logic if refactored.

---
*PR created automatically by Jules for task [2619257566863597434](https://jules.google.com/task/2619257566863597434) started by @kuasar-mknd*