### PR TITLE
🎨 Palette: Improve keyboard shortcuts robustness and visibility

### DIFF
--- a/src/components/common/Navigation.astro
+++ b/src/components/common/Navigation.astro
@@ -23,7 +23,7 @@ const currentPath = normalizePath(pathname);
       >
         Accueil <kbd
           class="font-sans ml-1 opacity-70 hidden md:inline-block text-[10px] bg-pacamara-primary/5 dark:bg-white/10 px-1.5 py-0.5 rounded"
-          aria-hidden="true">(1)</kbd
+          aria-hidden="true">(Alt+1)</kbd
         ></a
       >
     </li>
@@ -41,7 +41,7 @@ const currentPath = normalizePath(pathname);
       >
         Projets <kbd
           class="font-sans ml-1 opacity-70 hidden md:inline-block text-[10px] bg-pacamara-primary/5 dark:bg-white/10 px-1.5 py-0.5 rounded"
-          aria-hidden="true">(2)</kbd
+          aria-hidden="true">(Alt+2)</kbd
         ></a
       >
     </li>
@@ -59,7 +59,7 @@ const currentPath = normalizePath(pathname);
       >
         À propos <kbd
           class="font-sans ml-1 opacity-70 hidden md:inline-block text-[10px] bg-pacamara-primary/5 dark:bg-white/10 px-1.5 py-0.5 rounded"
-          aria-hidden="true">(3)</kbd
+          aria-hidden="true">(Alt+3)</kbd
         ></a
       >
     </li>

--- a/src/components/ui/HamburgerButton.astro
+++ b/src/components/ui/HamburgerButton.astro
@@ -187,19 +187,28 @@
       const isExpanded = button.getAttribute("aria-expanded") === "true";
       const target = e.target as HTMLElement;
 
-      // Ignore if user is typing in an input
+      // Ignore if user is typing in an input or using modifiers
       if (
         target.tagName === "INPUT" ||
         target.tagName === "TEXTAREA" ||
-        target.isContentEditable
+        target.isContentEditable ||
+        e.ctrlKey ||
+        e.metaKey ||
+        e.altKey
       ) {
         return;
       }
 
-      if ((e.key === "m" || e.key === "M") && !isExpanded) {
+      if (e.key === "m" || e.key === "M") {
         e.preventDefault();
-        openMenu();
-        if (liveRegion) liveRegion.textContent = "Menu ouvert";
+        if (isExpanded) {
+          closeMenu();
+          if (liveRegion) liveRegion.textContent = "Menu fermé";
+        } else {
+          openMenu();
+          if (liveRegion) liveRegion.textContent = "Menu ouvert";
+        }
+
         if (navigator.vibrate && !prefersReducedMotionQuery.matches) {
           navigator.vibrate(50);
         }

--- a/src/components/ui/ModeSwitch.astro
+++ b/src/components/ui/ModeSwitch.astro
@@ -89,7 +89,12 @@ import { Icon } from "astro-icon/components";
   };
 
   const handleGlobalKeydown = (e: KeyboardEvent) => {
-    if (e.shiftKey && (e.key === "T" || e.key === "t")) {
+    if (
+      e.shiftKey &&
+      (e.key === "T" || e.key === "t") &&
+      !e.ctrlKey &&
+      !e.metaKey
+    ) {
       const target = e.target as HTMLElement;
       if (
         target.tagName === "INPUT" ||


### PR DESCRIPTION
💡 What:
- Updated `HamburgerButton.astro` to toggle the menu with the 'M' key and added strict modifier key checks for global shortcuts.
- Updated `ModeSwitch.astro` with modifier key checks for the 'Shift+T' shortcut.
- Updated `Navigation.astro` to display explicit `(Alt+1)`, `(Alt+2)`, and `(Alt+3)` hints instead of just numbers.

🎯 Why:
- The 'M' shortcut was inconsistent (open only), and global shortcuts without modifier checks could accidentally trigger during browser-level shortcuts (e.g., Cmd+Shift+T).
- Navigation hints like '(1)' were ambiguous since the actual access keys require 'Alt' (or 'Control+Alt' on Mac) in most browsers.

📸 Before/After:
- Before: Menu 'M' only opened. Hints showed `(1)`.
- After: Menu 'M' toggles. Hints show `(Alt+1)`.

♿ Accessibility:
- Explicit shortcut hints improve discoverability for power users.
- Preventing shortcut collisions ensures screen reader and keyboard users don't trigger site actions while trying to use browser features.

---
*PR created automatically by Jules for task [4026857918303282933](https://jules.google.com/task/4026857918303282933) started by @kuasar-mknd*