### PR TITLE
⚡ Bolt: Cache DOM elements to prevent redundant lookups

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -105,3 +105,8 @@
 ## 2024-05-18 - Caching DOM queries in Header to prevent redundant lookups
 **Learning:** Querying `document.querySelectorAll` inside frequently triggered event listeners or mutation callbacks (like toggling a navigation menu inert states) causes redundant DOM lookups and unnecessary main-thread work.
 **Action:** Always cache main content DOM queries (like `main-content` and `main-footer` for inert settings) outside the open/close functions, ideally at the top of the initialization script block, to ensure O(1) query lookups on every menu toggle instead of N.
+
+## 2026-03-24 - Cache getElementById outside IntersectionObserver and Event Listeners
+
+**Learning:** Repeatedly querying the DOM with `document.getElementById` or `document.querySelector` inside frequently triggered event listeners (like `KeyboardEvent` for "Escape" or `onClick`) or callbacks (like `IntersectionObserver` callbacks) adds unnecessary main-thread overhead.
+**Action:** Cache these DOM elements at the module or initialization block level to ensure an O(1) direct reference during critical user interaction paths, improving responsiveness.

--- a/src/components/common/Header.astro
+++ b/src/components/common/Header.astro
@@ -150,6 +150,10 @@ const [logo1x, logo2x] = await Promise.all([
     const html = document.documentElement;
     // ⚡ Bolt: Cache DOM queries for inert background elements outside the toggle functions to avoid redundant lookups
     const bgElements = document.querySelectorAll("#main-content, #main-footer");
+    // ⚡ Bolt: Cache DOM query for the menu toggle button
+    const menuToggleBtn = document.querySelector(
+      'button[aria-controls="navigation_wrapper"]',
+    );
 
     // Guard clause if header elements aren't found
     if (!navWrapper) return;
@@ -187,10 +191,7 @@ const [logo1x, logo2x] = await Promise.all([
     function handleEscape(e: KeyboardEvent) {
       if (e.key === "Escape" && html.classList.contains("overflow-hidden")) {
         // Find and click the hamburger button to close
-        const btn = document.querySelector(
-          'button[aria-controls="navigation_wrapper"]',
-        );
-        if (btn instanceof HTMLElement) btn.click();
+        if (menuToggleBtn instanceof HTMLElement) menuToggleBtn.click();
       }
     }
 

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -374,6 +374,8 @@ const t = translations[lang as keyof typeof translations] || translations.fr;
         const progressCircle = document.getElementById(
           "scroll-progress-circle",
         );
+        // ⚡ Bolt: Cache DOM queries instead of querying repeatedly in callbacks
+        const mainContent = document.getElementById("main-content");
 
         // ⚡ Early return if elements don't exist
         if (!backToTopBtn || !sentinel || !progressCircle) return;
@@ -435,21 +437,27 @@ const t = translations[lang as keyof typeof translations] || translations.fr;
         backToTopObserver = new IntersectionObserver(
           (entries) => {
             const entry = entries[0];
-            const btn = document.getElementById("back-to-top");
-            if (!btn) return;
 
             // If sentinel is NOT intersecting (scrolled past), show button
             if (!entry.isIntersecting) {
-              btn.classList.remove("opacity-0", "invisible", "translate-y-4");
-              btn.classList.add("visible", "translate-y-0");
-              btn.setAttribute("tabindex", "0");
+              backToTopBtn.classList.remove(
+                "opacity-0",
+                "invisible",
+                "translate-y-4",
+              );
+              backToTopBtn.classList.add("visible", "translate-y-0");
+              backToTopBtn.setAttribute("tabindex", "0");
               // ⚡ Bolt: Only listen to scroll when button is visible to save resources
               window.addEventListener("scroll", onScroll, { passive: true });
               onScroll(); // Update visuals immediately
             } else {
-              btn.classList.add("opacity-0", "invisible", "translate-y-4");
-              btn.classList.remove("visible", "translate-y-0");
-              btn.setAttribute("tabindex", "-1");
+              backToTopBtn.classList.add(
+                "opacity-0",
+                "invisible",
+                "translate-y-4",
+              );
+              backToTopBtn.classList.remove("visible", "translate-y-0");
+              backToTopBtn.setAttribute("tabindex", "-1");
               // ⚡ Bolt: Detach listener when button is hidden to save main thread
               window.removeEventListener("scroll", onScroll);
             }
@@ -469,12 +477,11 @@ const t = translations[lang as keyof typeof translations] || translations.fr;
             navigator.vibrate(50);
           }
           window.scrollTo({ top: 0, behavior: "smooth" });
-          const main = document.getElementById("main-content");
-          if (main) {
-            if (!main.hasAttribute("tabindex")) {
-              main.setAttribute("tabindex", "-1");
+          if (mainContent) {
+            if (!mainContent.hasAttribute("tabindex")) {
+              mainContent.setAttribute("tabindex", "-1");
             }
-            main.focus({ preventScroll: true });
+            mainContent.focus({ preventScroll: true });
           }
         };
         backToTopBtn.addEventListener("click", onClick);


### PR DESCRIPTION
💡 What:
Cached DOM elements (`main-content`, `menu_toggle` button, etc.) outside of frequently triggered event listeners and observer callbacks in `Base.astro` and `Header.astro`.

🎯 Why:
Repeatedly querying the DOM with `document.getElementById` or `document.querySelector` inside frequent callbacks (like `IntersectionObserver` updates or `KeyboardEvent` listeners) adds unnecessary overhead and blocks the main thread. Caching ensures O(1) direct reference and reduces layout recalculations.

📊 Impact:
Reduces redundant DOM queries during scroll events and mobile menu interactions, saving main-thread CPU cycles and improving overall responsiveness.

🧪 Measurement:
Verify that the 'Back to top' button and the mobile menu still function exactly as before. The UI logic remains completely intact while removing internal DOM querying bottlenecks. Run `pnpm test:e2e` (or Playwright equivalent) to confirm.

---
*PR created automatically by Jules for task [17583244286342041954](https://jules.google.com/task/17583244286342041954) started by @kuasar-mknd*