### PR TITLE
🎨 Palette: Fix keyboard shortcut modifier and input checks

### DIFF
--- a/src/components/ui/ModeSwitch.astro
+++ b/src/components/ui/ModeSwitch.astro
@@ -93,7 +93,8 @@ import { Icon } from "astro-icon/components";
       e.shiftKey &&
       (e.key === "T" || e.key === "t") &&
       !e.ctrlKey &&
-      !e.metaKey
+      !e.metaKey &&
+      !e.altKey
     ) {
       const target = e.target as HTMLElement;
       if (

--- a/src/pages/cv/[...lang].astro
+++ b/src/pages/cv/[...lang].astro
@@ -516,7 +516,21 @@ const description = data.profile.content;
     };
 
     const handleKeydown = (e: KeyboardEvent) => {
-      if ((e.ctrlKey || e.metaKey) && e.key === "p") vibrate(50);
+      const target = e.target as HTMLElement;
+      if (
+        target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.isContentEditable
+      ) {
+        return;
+      }
+      if (
+        (e.ctrlKey || e.metaKey) &&
+        !e.altKey &&
+        !e.shiftKey &&
+        (e.key === "p" || e.key === "P")
+      )
+        vibrate(50);
     };
 
     const handlePrint = (e: Event) => {


### PR DESCRIPTION
💡 What: Added strict modifier checks (`!e.altKey`, `!e.shiftKey`) and input element guards to global keyboard shortcuts (`Shift+T` for theme toggle, `Ctrl+P` for CV print).
🎯 Why: Prevents the shortcuts from unintentionally intercepting browser or OS-level bindings, and prevents triggering them while typing in input fields, ensuring a smoother user experience and adhering to accessibility best practices.
📸 Before/After: N/A (Internal logic change)
♿ Accessibility: Improves keyboard navigation reliability by strictly adhering to intended shortcut combinations without conflicting with other tools or text input.

---
*PR created automatically by Jules for task [15755953798719649561](https://jules.google.com/task/15755953798719649561) started by @kuasar-mknd*