### PR TITLE
🎨 Palette: Improve Empty State CTA feedback

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -28,3 +28,7 @@
 ## 2026-04-08 - Global Keyboard Shortcuts
 **Learning:** When implementing global keyboard shortcuts (e.g., "T" for Back to Top), it is critical to explicitly check that modifier keys (`e.ctrlKey`, `e.metaKey`, `e.altKey`) are false. Failing to do so can intercept standard browser navigation commands (like Cmd+T to open a new tab), causing a severe UX regression.
 **Action:** Always include `!e.ctrlKey && !e.metaKey && !e.altKey` in global keydown event listeners, and ensure inputs (`INPUT`, `TEXTAREA`, `SELECT`, `isContentEditable`) are ignored.
+
+## 2026-04-10 - Empty State Call-to-Action Feedback
+**Learning:** Call-to-action links inside empty state components (e.g., "Aucun élément trouvé") can feel disconnected from the primary interactive patterns if they lack visual cues and reactive feedback. Users might miss them as actionable items.
+**Action:** Enhance empty state CTA links by wrapping their text in a `span`, appending a directional icon (like `mdi:arrow-right`), and utilizing `group-hover` and `group-focus-visible` Tailwind classes with `transition-transform` to introduce a subtle directional micro-interaction.

--- a/src/components/ui/EmptyState.astro
+++ b/src/components/ui/EmptyState.astro
@@ -44,10 +44,15 @@ const safeActionUrl = actionUrl ? sanitizeUrl(actionUrl) : undefined;
     safeActionUrl && (
       <a
         href={safeActionUrl}
-        class="inline-flex items-center justify-center px-6 py-3 bg-pacamara-secondary/10 dark:bg-white/10 hover:bg-pacamara-secondary/20 dark:hover:bg-white/20 focus-visible:bg-pacamara-secondary/20 dark:focus-visible:bg-white/20 text-pacamara-primary dark:text-white font-medium rounded-xl transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pacamara-accent focus-visible:ring-offset-2 shadow-sm hover:shadow-md focus-visible:shadow-md"
+        class="group inline-flex items-center justify-center gap-2 px-6 py-3 bg-pacamara-secondary/10 dark:bg-white/10 hover:bg-pacamara-secondary/20 dark:hover:bg-white/20 focus-visible:bg-pacamara-secondary/20 dark:focus-visible:bg-white/20 text-pacamara-primary dark:text-white font-medium rounded-xl transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pacamara-accent focus-visible:ring-offset-2 shadow-sm hover:shadow-md focus-visible:shadow-md"
         data-empty-state-cta="true"
       >
-        {actionText}
+        <span>{actionText}</span>
+        <Icon
+          name="mdi:arrow-right"
+          class="w-5 h-5 transition-transform duration-300 group-hover:translate-x-1 group-focus-visible:translate-x-1"
+          aria-hidden="true"
+        />
       </a>
     )
   }


### PR DESCRIPTION
💡 What: Added an arrow icon (`mdi:arrow-right`) and a subtle interactive translation animation to the generic Call-To-Action (CTA) link in `EmptyState.astro`.
🎯 Why: Call-to-action links inside empty state components lacked visual cues, making them feel disconnected from the app's primary interactive patterns. This provides users with clearer visual feedback and encourages interaction by mimicking standard button behavior.
📸 Before/After: Visual verified via Playwright screenshot; the `Retour` button now includes a forward/return arrow.
♿ Accessibility: Included `aria-hidden="true"` on the newly added `<Icon />` to avoid redundant screen reader announcements while providing the visual cue for sighted users.

---
*PR created automatically by Jules for task [2399192275849353852](https://jules.google.com/task/2399192275849353852) started by @kuasar-mknd*