### PR TITLE
🎨 Palette: Ignore SELECT in global keyboard shortcuts

### DIFF
--- a/src/components/common/Navigation.astro
+++ b/src/components/common/Navigation.astro
@@ -115,6 +115,7 @@ const currentPath = normalizePath(pathname);
     const target = e.target as HTMLElement;
     if (
       target.tagName === "INPUT" ||
+      target.tagName === "SELECT" ||
       target.tagName === "TEXTAREA" ||
       target.isContentEditable
     ) {

--- a/src/components/ui/HamburgerButton.astro
+++ b/src/components/ui/HamburgerButton.astro
@@ -190,6 +190,7 @@
       // Ignore if user is typing in an input or using modifiers
       if (
         target.tagName === "INPUT" ||
+        target.tagName === "SELECT" ||
         target.tagName === "TEXTAREA" ||
         target.isContentEditable ||
         e.ctrlKey ||

--- a/src/components/ui/ModeSwitch.astro
+++ b/src/components/ui/ModeSwitch.astro
@@ -99,6 +99,7 @@ import { Icon } from "astro-icon/components";
       const target = e.target as HTMLElement;
       if (
         target.tagName === "INPUT" ||
+        target.tagName === "SELECT" ||
         target.tagName === "TEXTAREA" ||
         target.isContentEditable
       ) {

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -493,6 +493,7 @@ const t = translations[lang as keyof typeof translations] || translations.fr;
           // Ignore if user is typing in an input
           if (
             target.tagName === "INPUT" ||
+            target.tagName === "SELECT" ||
             target.tagName === "TEXTAREA" ||
             target.isContentEditable
           ) {

--- a/src/pages/cv/[...lang].astro
+++ b/src/pages/cv/[...lang].astro
@@ -519,6 +519,7 @@ const description = data.profile.content;
       const target = e.target as HTMLElement;
       if (
         target.tagName === "INPUT" ||
+        target.tagName === "SELECT" ||
         target.tagName === "TEXTAREA" ||
         target.isContentEditable
       ) {


### PR DESCRIPTION
💡 What: Added `target.tagName === 'SELECT'` to the ignore list in all global keyboard shortcut event listeners (`Navigation.astro`, `HamburgerButton.astro`, `ModeSwitch.astro`, `Base.astro`, and `cv/[...lang].astro`).
🎯 Why: Without this check, native dropdown interactions involving the keyboard (arrows, space, text search) could trigger unintended global shortcuts, interrupting the user.
📸 Before/After: Visuals remain unchanged.
♿ Accessibility: Ensures that keyboard users interacting with `<select>` elements do not accidentally trigger global actions like navigation, theme switching, or menu toggling.

---
*PR created automatically by Jules for task [12789310630358231298](https://jules.google.com/task/12789310630358231298) started by @kuasar-mknd*