### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,0 +1,5 @@
+🚨 Severity: LOW/MEDIUM
+💡 Vulnerability: External fetch calls in server-side functions (Vimeo poster fetching and jsdelivr CDN font loading) were missing timeout constraints.
+🎯 Impact: Without timeouts, hanging external requests can tie up serverless function instances, potentially leading to resource exhaustion or denial of service (DoS) for the application.
+🔧 Fix: Added `AbortController` combined with a 10s `setTimeout` to all external `fetch` calls. Correctly implemented `clearTimeout` to avoid memory leaks.
+✅ Verification: Tested via unit tests (`bun test`) ensuring mock fetches resolve, format check passed, and E2E tests (`pnpm test:e2e`) ran correctly without unexpected crashes.

--- a/src/pages/og/[slug].png.ts
+++ b/src/pages/og/[slug].png.ts
@@ -19,9 +19,21 @@ export const GET: APIRoute = async ({ props }) => {
 
   // Load font (Inter Bold) from CDN (WOFF is supported by Satori)
   if (!fontPromise) {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 10000);
+
     fontPromise = fetch(
       "https://cdn.jsdelivr.net/npm/@fontsource/inter@5.0.8/files/inter-latin-700-normal.woff",
-    ).then((res) => res.arrayBuffer());
+      { signal: controller.signal },
+    )
+      .then((res) => {
+        clearTimeout(timeoutId);
+        return res.arrayBuffer();
+      })
+      .catch((e) => {
+        clearTimeout(timeoutId);
+        throw e;
+      });
   }
   const fontData = await fontPromise;
 

--- a/src/utils/async.ts
+++ b/src/utils/async.ts
@@ -49,9 +49,16 @@ export async function fetchVimeoPosterWithCache(
   }
 
   try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 10000);
+
     const response = await fetch(
       `https://vimeo.com/api/oembed.json?url=${encodeURIComponent(videoUrl)}`,
+      { signal: controller.signal },
     );
+
+    clearTimeout(timeoutId);
+
     const data = await response.json();
     vimeoPosterCache.set(videoUrl, data.thumbnail_url);
     return data.thumbnail_url;

--- a/tests/pages/og/slug.png.spec.ts
+++ b/tests/pages/og/slug.png.spec.ts
@@ -50,7 +50,8 @@ mock.module("../../../src/utils/projects", () => ({
 }));
 
 // Import the module to test AFTER mocks
-const { getStaticPaths, GET } = await import("../../../src/pages/og/[slug].png");
+const { getStaticPaths, GET } =
+  await import("../../../src/pages/og/[slug].png");
 
 // Mock fetch for the font
 const originalFetch = global.fetch;
@@ -99,6 +100,7 @@ describe("OG Image Generation", () => {
       expect(global.fetch).toHaveBeenCalledTimes(1);
       expect(global.fetch).toHaveBeenCalledWith(
         "https://cdn.jsdelivr.net/npm/@fontsource/inter@5.0.8/files/inter-latin-700-normal.woff",
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
       );
 
       // Verify satori call


### PR DESCRIPTION
🚨 Severity: LOW/MEDIUM
💡 Vulnerability: External fetch calls in server-side functions (Vimeo poster fetching and jsdelivr CDN font loading) were missing timeout constraints.
🎯 Impact: Without timeouts, hanging external requests can tie up serverless function instances, potentially leading to resource exhaustion or denial of service (DoS) for the application.
🔧 Fix: Added `AbortController` combined with a 10s `setTimeout` to all external `fetch` calls. Correctly implemented `clearTimeout` to avoid memory leaks.
✅ Verification: Tested via unit tests (`bun test`) ensuring mock fetches resolve, format check passed, and E2E tests (`pnpm test:e2e`) ran correctly without unexpected crashes.

---
*PR created automatically by Jules for task [5809201882274543762](https://jules.google.com/task/5809201882274543762) started by @kuasar-mknd*