### PR TITLE
🛡️ Sentinel: [HIGH] Fix DoS vulnerability by adding timeout to external fetch call

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,11 @@
 ## 2025-04-10 - Strict Validation for Localhost Origins in Proxies
+
 **Vulnerability:** CORS Bypass / SSRF in Serverless Proxy
 **Learning:** Permissive CORS checks like `origin.startsWith("http://localhost:")` in proxy endpoints allow attackers to craft malicious domains (e.g., `http://localhost:8080.evil.com`) that successfully bypass validation and allow cross-origin requests.
 **Prevention:** Use a strict regular expression such as `/^http:\/\/localhost(:\d+)?$/` to validate localhost origins, ensuring no trailing paths or malicious domain suffixes are allowed.
+
+## 2024-04-13 - [Add timeout to external API calls in serverless function]
+
+**Vulnerability:** The server-side proxy function `functions/api/submit.ts` lacked a timeout on its external `fetch` request.
+**Learning:** Cloudflare Pages Functions (serverless workers) can hang indefinitely and consume concurrency limits if external APIs are unresponsive, creating a DoS vulnerability.
+**Prevention:** Always wrap `fetch` calls in serverless environments with an `AbortController` and a strict timeout (e.g. `setTimeout`), ensuring `clearTimeout` is called when the request successfully resolves.

--- a/functions/api/submit.ts
+++ b/functions/api/submit.ts
@@ -27,6 +27,10 @@ export async function onRequestPost(context: {
     const data = await context.request.json();
     data.access_key = context.env.WEB3FORMS_ACCESS_KEY;
 
+    // 🛡️ Sentinel: Implement timeout to prevent hanging connections (DoS mitigation)
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 10000);
+
     const response = await fetch("https://api.web3forms.com/submit", {
       method: "POST",
       headers: {
@@ -34,7 +38,10 @@ export async function onRequestPost(context: {
         Accept: "application/json",
       },
       body: JSON.stringify(data),
+      signal: controller.signal,
     });
+
+    clearTimeout(timeoutId);
 
     const result = await response.json();
     return new Response(JSON.stringify(result), {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Missing timeout constraints in the server-side `functions/api/submit.ts` proxy endpoint.
🎯 Impact: Without a timeout on the `fetch` call to the external Web3Forms API, a slow or unresponsive external server could cause the Cloudflare Pages Function to hang indefinitely. This ties up concurrent connections/memory limits, potentially leading to a Denial of Service (DoS) for the application.
🔧 Fix: Implemented an `AbortController` accompanied by a 10,000ms `setTimeout` on the `fetch` request, and ensured to `clearTimeout` when completed, preventing the connection from hanging indefinitely.
✅ Verification: Ran `pnpm lint`, `bun test`, and `pnpm test:e2e` to verify no regressions were introduced. Evaluated changes through manual review in code.

---
*PR created automatically by Jules for task [983389994706828732](https://jules.google.com/task/983389994706828732) started by @kuasar-mknd*