### PR TITLE
🎨 Palette: Add keyboard shortcut for article sharing

### DIFF
--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,5 +1,14 @@
-🚨 Severity: LOW/MEDIUM
-💡 Vulnerability: External fetch calls in server-side functions (Vimeo poster fetching and jsdelivr CDN font loading) were missing timeout constraints.
-🎯 Impact: Without timeouts, hanging external requests can tie up serverless function instances, potentially leading to resource exhaustion or denial of service (DoS) for the application.
-🔧 Fix: Added `AbortController` combined with a 10s `setTimeout` to all external `fetch` calls. Correctly implemented `clearTimeout` to avoid memory leaks.
-✅ Verification: Tested via unit tests (`bun test`) ensuring mock fetches resolve, format check passed, and E2E tests (`pnpm test:e2e`) ran correctly without unexpected crashes.
+💡 What:
+Added a global keyboard shortcut (`S`) to trigger the "Share" functionality on standard articles (`src/pages/[slug].astro`), matching the behavior already present on project pages. Also added visual `kbd` hints and proper ARIA shortcut attributes.
+
+🎯 Why:
+To improve consistency, discoverability, and accessibility. Project pages already had this shortcut and hint, but standard pages were missing it, creating a disjointed user experience for keyboard users.
+
+📸 Before/After:
+Before: The "Partager" button had no shortcut, no `kbd` visual hint, and no `aria-keyshortcuts` attribute.
+After: The button now reads "Partager (S)" with a visual `kbd` hint, uses `aria-keyshortcuts="S"`, and correctly triggers when pressing "S".
+
+♿ Accessibility:
+- Added `aria-keyshortcuts="S"`
+- Updated `aria-label` to explicitly include the shortcut keys.
+- Prevented keyboard trap/conflict by ensuring shortcut does not fire when typing inside `INPUT`, `SELECT`, `TEXTAREA` or `contenteditable` elements.

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -67,4 +67,5 @@ declare module "plyr";
 
 interface Window {
   __projectInteractionsInitHandler?: () => void;
+  __articleKeydownHandler?: (e: KeyboardEvent) => void;
 }

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -76,7 +76,8 @@ const readingTime = getReadingTime(entry.body);
         <button
           id="share-btn"
           class="group relative overflow-hidden rounded-full bg-transparent hover:bg-pacamara-secondary/5 transition-all duration-300 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pacamara-accent focus-visible:ring-offset-2 px-3 py-1 -mx-3"
-          aria-label="Partager cet article"
+          aria-label="Partager cet article (S)"
+          aria-keyshortcuts="S"
         >
           <div class="grid grid-cols-1 grid-rows-1 place-items-center">
             <!-- Normal State -->
@@ -88,7 +89,12 @@ const readingTime = getReadingTime(entry.body);
                 class="w-4 h-4"
                 aria-hidden="true"
               />
-              <span>Partager</span>
+              <span class="font-medium"
+                >Partager <kbd
+                  class="font-sans ml-1 opacity-70 hidden sm:inline-block text-[10px] bg-pacamara-primary/5 dark:bg-white/10 px-1.5 py-0.5 rounded"
+                  aria-hidden="true">(S)</kbd
+                ></span
+              >
             </div>
             <!-- Copied State -->
             <div
@@ -146,6 +152,38 @@ const readingTime = getReadingTime(entry.body);
 <script>
   const shareBtn = document.getElementById("share-btn");
   const announcer = document.getElementById("share-announcer");
+
+  const handleArticleKeydown = (e: KeyboardEvent) => {
+    const target = e.target as HTMLElement;
+
+    // Ignore if user is typing
+    if (
+      target.tagName === "INPUT" ||
+      target.tagName === "SELECT" ||
+      target.tagName === "TEXTAREA" ||
+      target.isContentEditable
+    ) {
+      return;
+    }
+
+    if (
+      (e.key === "s" || e.key === "S") &&
+      !e.ctrlKey &&
+      !e.metaKey &&
+      !e.altKey
+    ) {
+      if (shareBtn) {
+        e.preventDefault();
+        shareBtn.click();
+      }
+    }
+  };
+
+  if (window.__articleKeydownHandler) {
+    document.removeEventListener("keydown", window.__articleKeydownHandler);
+  }
+  window.__articleKeydownHandler = handleArticleKeydown;
+  document.addEventListener("keydown", window.__articleKeydownHandler);
 
   const prefersReducedMotionQuery = window.matchMedia(
     "(prefers-reduced-motion: reduce)",


### PR DESCRIPTION
💡 What:
Added a global keyboard shortcut (`S`) to trigger the "Share" functionality on standard articles (`src/pages/[slug].astro`), matching the behavior already present on project pages. Also added visual `kbd` hints and proper ARIA shortcut attributes.

🎯 Why:
To improve consistency, discoverability, and accessibility. Project pages already had this shortcut and hint, but standard pages were missing it, creating a disjointed user experience for keyboard users.

📸 Before/After:
Before: The "Partager" button had no shortcut, no `kbd` visual hint, and no `aria-keyshortcuts` attribute.
After: The button now reads "Partager (S)" with a visual `kbd` hint, uses `aria-keyshortcuts="S"`, and correctly triggers when pressing "S".

♿ Accessibility:
- Added `aria-keyshortcuts="S"`
- Updated `aria-label` to explicitly include the shortcut keys.
- Prevented keyboard trap/conflict by ensuring shortcut does not fire when typing inside `INPUT`, `SELECT`, `TEXTAREA` or `contenteditable` elements.

---
*PR created automatically by Jules for task [12918059760288753410](https://jules.google.com/task/12918059760288753410) started by @kuasar-mknd*