### PR TITLE
🎨 Palette: Add keyboard shortcuts to project pagination

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -49,3 +49,7 @@
 
 **Learning:** Adding custom JavaScript event listeners to individual components to call `navigator.vibrate()` is redundant and can lead to duplicated logic. The project already has a global `initHaptics()` listener set up in `src/layouts/Base.astro`.
 **Action:** Always leverage the centralized haptics management by simply adding the `data-haptic` attribute (e.g., `data-haptic="30"` or `data-haptic="50"`) directly to the HTML markup of the interactive element. No custom JS listeners are needed.
+
+## 2026-04-14 - Pagination Accessibility & Navigation Context
+**Learning:** When adding keyboard shortcuts to pagination controls in a Single Page Application (SPA) utilizing View Transitions (like Astro's `astro:page-load`), global event listeners (like `document.addEventListener("keydown", ...)`) must be explicitly managed. They must be registered with a singleton pattern, where the previous instance is removed on subsequent page loads, otherwise memory leaks and duplicate trigger events will occur on every keystroke. Furthermore, when adding elements like `<kbd>` hints to Astro pagination controls, you must account for both active `<a>` tags and inactive boundary states, where the controls render as disabled `<span>` elements with `cursor-not-allowed` class.
+**Action:** Always test pagination components on both the first and last pages to ensure interactive styles (like hovers and keyboard shortcuts) don't apply to disabled states, and wrap global event listener additions in a cleanup check to ensure they survive SPA transitions intact.

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -69,3 +69,8 @@ interface Window {
   __projectInteractionsInitHandler?: () => void;
   __articleKeydownHandler?: (e: KeyboardEvent) => void;
 }
+
+interface Window {
+  __paginationKeydownHandler?: (e: KeyboardEvent) => void;
+  __paginationInteractionsInitHandler?: () => void;
+}

--- a/src/pages/project/[...page].astro
+++ b/src/pages/project/[...page].astro
@@ -154,9 +154,11 @@ const collectionJsonLd = {
           <div class="flex items-center gap-4">
             {page.url.prev ? (
               <a
+                id="prev-page-link"
                 href={sanitizeUrl(page.url.prev)}
                 class="group flex items-center gap-2 text-base bg-transparent border border-pacamara-secondary leading-none rounded-full py-3 px-6 text-pacamara-secondary hover:bg-pacamara-accent hover:border-pacamara-accent hover:text-pacamara-white transition-all duration-300 font-pacamara-space font-bold hover-scale-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pacamara-accent focus-visible:ring-offset-2"
-                aria-label={`Précédent (page ${page.currentPage - 1})`}
+                aria-label={`Précédent (page ${page.currentPage - 1}) ([)`}
+                aria-keyshortcuts="["
                 data-haptic="30"
               >
                 <Icon
@@ -165,6 +167,12 @@ const collectionJsonLd = {
                   aria-hidden="true"
                 />
                 <span>Précédent</span>
+                <kbd
+                  class="font-sans ml-1 opacity-70 hidden sm:inline-block text-[10px] bg-pacamara-primary/5 dark:bg-white/10 px-1.5 py-0.5 rounded"
+                  aria-hidden="true"
+                >
+                  [
+                </kbd>
               </a>
             ) : (
               <span
@@ -182,12 +190,20 @@ const collectionJsonLd = {
 
             {page.url.next ? (
               <a
+                id="next-page-link"
                 href={sanitizeUrl(page.url.next)}
                 class="group flex items-center gap-2 text-base bg-transparent border border-pacamara-secondary leading-none rounded-full py-3 px-6 text-pacamara-secondary hover:bg-pacamara-accent hover:border-pacamara-accent hover:text-pacamara-white transition-all duration-300 font-pacamara-space font-bold hover-scale-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pacamara-accent focus-visible:ring-offset-2"
-                aria-label={`Suivant (page ${page.currentPage + 1})`}
+                aria-label={`Suivant (page ${page.currentPage + 1}) (])`}
+                aria-keyshortcuts="]"
                 data-haptic="30"
               >
                 <span>Suivant</span>
+                <kbd
+                  class="font-sans ml-1 opacity-70 hidden sm:inline-block text-[10px] bg-pacamara-primary/5 dark:bg-white/10 px-1.5 py-0.5 rounded"
+                  aria-hidden="true"
+                >
+                  ]
+                </kbd>
                 <Icon
                   name="mdi:arrow-right"
                   class="w-5 h-5 transition-transform group-hover:translate-x-1 group-focus-visible:translate-x-1"
@@ -227,3 +243,67 @@ const collectionJsonLd = {
     }
   </section>
 </Base>
+
+<script>
+  /**
+   * 🎨 Palette: Pagination Keyboard Shortcuts
+   * - [ : Previous Page
+   * - ] : Next Page
+   */
+  function initPaginationInteractions() {
+    const prevLink = document.getElementById(
+      "prev-page-link",
+    ) as HTMLAnchorElement;
+    const nextLink = document.getElementById(
+      "next-page-link",
+    ) as HTMLAnchorElement;
+
+    const handlePaginationKeydown = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+
+      if (
+        target.tagName === "INPUT" ||
+        target.tagName === "SELECT" ||
+        target.tagName === "TEXTAREA" ||
+        target.isContentEditable
+      ) {
+        return;
+      }
+
+      if (e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) {
+        return;
+      }
+
+      if (e.key === "[") {
+        if (prevLink) {
+          e.preventDefault();
+          prevLink.click();
+        }
+      } else if (e.key === "]") {
+        if (nextLink) {
+          e.preventDefault();
+          nextLink.click();
+        }
+      }
+    };
+
+    if (window.__paginationKeydownHandler) {
+      document.removeEventListener(
+        "keydown",
+        window.__paginationKeydownHandler,
+      );
+    }
+    window.__paginationKeydownHandler = handlePaginationKeydown;
+    document.addEventListener("keydown", window.__paginationKeydownHandler);
+  }
+
+  if (window.__paginationInteractionsInitHandler) {
+    document.removeEventListener(
+      "astro:page-load",
+      window.__paginationInteractionsInitHandler,
+    );
+  }
+  window.__paginationInteractionsInitHandler = initPaginationInteractions;
+  document.addEventListener("astro:page-load", initPaginationInteractions);
+  initPaginationInteractions();
+</script>


### PR DESCRIPTION
## 💡 What:
Added `[` (Previous) and `]` (Next) keyboard shortcuts to the project pagination links (`src/pages/project/[...page].astro`). Also appended subtle visual `<kbd>` hints directly to the navigation buttons.

## 🎯 Why:
To create a more intuitive, consistent navigation experience. Individual project pages (`/project/[slug]`) and the image Lightbox already utilize the `[` and `]` keys for chronological and visual navigation. Extending this same mental model to the primary pagination view reduces friction and satisfies expectations for keyboard-first users.

## 📸 Before/After:
**Before:** Pagination was strictly point-and-click or standard sequential tabbing.
**After:** Pagination links can be triggered by hitting `[` and `]`, while respecting input focus. `<kbd>[<kbd>` and `<kbd>]<kbd>` icons visually guide the user.

## ♿ Accessibility:
- Attached dynamic `aria-keyshortcuts="["` and `"]"` to the active page navigation links.
- Screen readers announce the shortcut mapping context directly in the active link `aria-label`.
- Shortcut listener safely skips execution if the user is typing in form inputs (`INPUT`, `TEXTAREA`, `SELECT`) or holding modifier keys (`Ctrl`/`Alt`/`Meta`), preventing conflicts with native browser commands or screen reader behaviors.

---
*PR created automatically by Jules for task [2963119939772709318](https://jules.google.com/task/2963119939772709318) started by @kuasar-mknd*