### PR TITLE
🛡️ Sentinel: [HIGH] Fix Web3Forms access key DOM exposure

### DIFF
--- a/src/components/common/ContactForm.astro
+++ b/src/components/common/ContactForm.astro
@@ -1,14 +1,11 @@
 ---
 import { Icon } from "astro-icon/components";
-
-const WEB3FORMS_ACCESS_KEY = import.meta.env.WEB3FORMS_ACCESS_KEY;
 ---
 
 {
   /* ⚡ Bolt: Performance Optimization - content-visibility skips rendering when off-screen */
 }
 <form
-  data-key={import.meta.env.DEV ? WEB3FORMS_ACCESS_KEY : ""}
   action={import.meta.env.DEV
     ? "https://api.web3forms.com/submit"
     : "/api/submit"}
@@ -821,9 +818,17 @@ const WEB3FORMS_ACCESS_KEY = import.meta.env.WEB3FORMS_ACCESS_KEY;
         try {
           const formData = new FormData(this.form);
           const data: Record<string, string> = {};
-          const encodedKey = this.form.getAttribute("data-key");
-          if (encodedKey) {
-            data["access_key"] = encodedKey;
+          if (import.meta.env.DEV) {
+            try {
+              const res = await fetch("/api/dev-key");
+              if (res.ok) {
+                const json = await res.json();
+                if (json.key) data["access_key"] = json.key;
+              }
+            } catch (e) {
+              // eslint-disable-next-line no-console
+              console.error(e);
+            }
           }
           const allowedFields = new Set([
             "name",

--- a/src/pages/api/dev-key.ts
+++ b/src/pages/api/dev-key.ts
@@ -1,0 +1,17 @@
+import type { APIRoute } from "astro";
+
+export const GET: APIRoute = () => {
+  if (!import.meta.env.DEV) {
+    return new Response(JSON.stringify({ error: "Not found" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  return new Response(
+    JSON.stringify({ key: import.meta.env.WEB3FORMS_ACCESS_KEY || "" }),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+};


### PR DESCRIPTION
🎯 **What:** Removed the `data-key` attribute from the contact form that exposed the Web3Forms API key in the DOM during DEV mode.

⚠️ **Risk:** While only injected in development, DOM exposure of secrets is a bad practice. If the development flag was ever bypassed or if a staging environment mistakenly ran in DEV mode, the access key could be trivially scraped by bots or malicious actors, leading to quota exhaustion or unauthorized submissions.

🛡️ **Solution:** Created a dedicated API route (`/api/dev-key`) that safely serves the key only when `import.meta.env.DEV` is true. The client-side form now dynamically fetches this key at submission time instead of reading it statically from the DOM, ensuring the secret never resides in the HTML markup.

---
*PR created automatically by Jules for task [14447710580584398054](https://jules.google.com/task/14447710580584398054) started by @kuasar-mknd*