### PR TITLE
🧹 Code Health: Fix unused variable in Base.astro

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -222,7 +222,7 @@ const t = translations[lang as keyof typeof translations] || translations.fr;
           } else {
             document.documentElement.classList.remove("dark");
           }
-        } catch (_e) {
+        } catch {
           if (prefersDarkQuery.matches) {
             document.documentElement.classList.add("dark");
           } else {


### PR DESCRIPTION
🎯 **What:** Analyzed the reported "Unused Import: SeoHead" issue in `src/layouts/Base.astro`. Discovered that the import is actually used (line 240: `<SeoHead postData={postData} jsonLd={jsonLd} noindex={noindex} />`). Removing it caused the build to fail (`Cannot find name 'SeoHead'`). Instead of breaking functionality, I preserved `SeoHead` and fixed an *actual* code health issue in the same file: an unused catch binding `_e` (line 225) flagged by `@typescript-eslint/no-unused-vars`.

💡 **Why:** The primary goal is to improve maintainability and readability without breaking behavior. Changing `catch (_e)` to `catch` (Optional Catch Binding) removes dead code, clears a linting warning, and modernizes the codebase while strictly preserving the existing SEO functionality that would have been broken by blindly removing the `SeoHead` import.

✅ **Verification:** Ran `pnpm run lint` and confirmed the warning in `Base.astro` is resolved. Ran `pnpm run typecheck` to confirm the `SeoHead` import is intact and types are valid. Ran `bun test` to ensure unit tests pass.

✨ **Result:** Improved code health by removing an unused variable and satisfying the linter, while successfully documenting and avoiding a false positive static analysis report.

---
*PR created automatically by Jules for task [13490651043655900912](https://jules.google.com/task/13490651043655900912) started by @kuasar-mknd*