### PR TITLE
🎨 Palette: Pagination Accessibility & Keyboard Hints (x2)

### DIFF
--- a/src/pages/project/[...page].astro
+++ b/src/pages/project/[...page].astro
@@ -177,7 +177,7 @@ const collectionJsonLd = {
             ) : (
               <span
                 class="flex items-center gap-2 text-base bg-transparent border border-pacamara-secondary/30 leading-none rounded-full py-3 px-6 text-pacamara-secondary/30 font-pacamara-space font-bold cursor-not-allowed select-none"
-                aria-hidden="true"
+                aria-disabled="true"
               >
                 <Icon
                   name="mdi:arrow-left"
@@ -185,6 +185,12 @@ const collectionJsonLd = {
                   aria-hidden="true"
                 />
                 <span>Précédent</span>
+                <kbd
+                  class="font-sans ml-1 opacity-70 hidden sm:inline-block text-[10px] bg-pacamara-primary/5 dark:bg-white/10 px-1.5 py-0.5 rounded"
+                  aria-hidden="true"
+                >
+                  [
+                </kbd>
               </span>
             )}
 
@@ -213,9 +219,15 @@ const collectionJsonLd = {
             ) : (
               <span
                 class="flex items-center gap-2 text-base bg-transparent border border-pacamara-secondary/30 leading-none rounded-full py-3 px-6 text-pacamara-secondary/30 font-pacamara-space font-bold cursor-not-allowed select-none"
-                aria-hidden="true"
+                aria-disabled="true"
               >
                 <span>Suivant</span>
+                <kbd
+                  class="font-sans ml-1 opacity-70 hidden sm:inline-block text-[10px] bg-pacamara-primary/5 dark:bg-white/10 px-1.5 py-0.5 rounded"
+                  aria-hidden="true"
+                >
+                  ]
+                </kbd>
                 <Icon
                   name="mdi:arrow-right"
                   class="w-5 h-5 opacity-50"


### PR DESCRIPTION
🎯 Cluster: Pagination Accessibility & UX
📄 Files: src/pages/project/[...page].astro
♿ A11y: Changed `aria-hidden="true"` to `aria-disabled="true"` on disabled pagination buttons and added `<kbd>` hints for keyboard shortcuts (`[` and `]`).

---
*PR created automatically by Jules for task [11359660637543546782](https://jules.google.com/task/11359660637543546782) started by @kuasar-mknd*