### PR TITLE
🧭 DocOps: docs + GitHub workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,6 +31,7 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
+          queries: security-extended,security-and-quality
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v4

--- a/.jules/docops-history.md
+++ b/.jules/docops-history.md
@@ -48,3 +48,4 @@
 | 2026-04-17 | Documentation & Workflows | README.md, docs/ARCHITECTURE.md, docs/AI.md, docs/ENV.md, .github/workflows/codeql.yml, .github/workflows/dependency-review.yml | Updated verification timestamps and documented the pnpm run test command in README.md. |
 | 2026-04-18 | Audit & Verification | None | Verified documentation is accurate, complete, and perfectly mirrors the codebase capabilities and constraints. Checked CI/CD scripts. No changes needed to prevent looping and unnecessary rewrites. |
 | 2026-04-18 | Update Documentation & Workflows | docs/API.md, .github/workflows/ci.yml, .github/dependabot.yml | Added rate limiting section, dynamic Prisma CI check, and dependabot groups. |
+| 2026-04-19 | Client/Server Variables & AI Security | docs/ENV.md, docs/AI.md, .github/workflows/codeql.yml | Added explicit Astro SSG Client/Server env variable documentation, reinforced server-side AI key management, and enhanced CodeQL security rules. |

--- a/docs/AI.md
+++ b/docs/AI.md
@@ -14,7 +14,7 @@ If implemented, the AI adapter will require the following:
 - **Provider**: Local AI (e.g., Ollama) or Cloud API (OpenAI/Anthropic).
 - **Location**: The logic will reside in a build script or Astro integration (`src/utils/ai.ts`), not a live Hono backend.
 - **Environment Variables**:
-  - `AI_API_KEY`: The secret key to access the LLM provider.
+  - `AI_API_KEY`: The secret key to access the LLM provider. **Important:** This must never use the `PUBLIC_` prefix to ensure strict server-side management.
   - `AI_MODEL_NAME`: The model version to use (e.g., `gpt-4o-mini`, `llama3`).
   - *These variables must be added to `src/env.d.ts` and `.env.example` before use.* (Currently, they do not exist in the codebase).
 

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -13,6 +13,14 @@ The following variables must be set in your `.env` file (locally) or in your CI/
 
 _(Note: No Prisma `DATABASE_URL` or Hono backend environment variables are required as this is a fully static frontend application built on Astro. There is no Hono framework used in this repository. The Cloudflare analytics token is strictly optional)._
 
+## 🔒 Client vs Server Variables (Astro SSG)
+
+In Astro, environment variables must be prefixed with `PUBLIC_` to be accessible on the client-side (browser).
+- **Server-side only**: `WEB3FORMS_ACCESS_KEY`
+- **Client-side**: `PUBLIC_CF_ANALYTICS_TOKEN`
+
+Variables without the `PUBLIC_` prefix are strictly server-side. Attempting to use them in client-side code will result in `undefined`.
+
 ## 🛡 Secrets
 
 **NEVER** commit your `.env` file containing real values. Use `.env.example` as a template.


### PR DESCRIPTION
**What docs changed:**
- `docs/ENV.md`: Added a new "Client vs Server Variables (Astro SSG)" section detailing the requirement of the `PUBLIC_` prefix for client-side exposure.
- `docs/AI.md`: Emphasized that `AI_API_KEY` must never use the `PUBLIC_` prefix to enforce strict server-side management.

**What workflows were added/updated:**
- `.github/workflows/codeql.yml`: Enhanced the initialization step by adding `queries: security-extended,security-and-quality` for production-grade security scanning.

**How to verify:**
1. Read `docs/ENV.md` to confirm the new variables section is present.
2. Read `docs/AI.md` to confirm the `AI_API_KEY` warning.
3. Check `.github/workflows/codeql.yml` to ensure the extended queries are included.
4. Run `pnpm run check`, `bun test src/ tests/`, and `pnpm run test:e2e` to confirm no breaking changes were introduced.

**Notes about assumptions:**
- Assumed Node 20 / pnpm based on existing configurations.
- Assumed the repository architecture remains fully static Astro SSG, thus reinforcing Astro-specific variable scoping rather than hypothetical Hono configurations.
- Updated `.jules/docops-history.md` as required by the DocOps boundaries to prevent future agent loops.

---
*PR created automatically by Jules for task [17847003852248127919](https://jules.google.com/task/17847003852248127919) started by @kuasar-mknd*