### PR TITLE
🧭 DocOps: docs + GitHub workflows

### DIFF
--- a/.jules/docops-history.md
+++ b/.jules/docops-history.md
@@ -49,3 +49,4 @@
 | 2026-04-18 | Audit & Verification | None | Verified documentation is accurate, complete, and perfectly mirrors the codebase capabilities and constraints. Checked CI/CD scripts. No changes needed to prevent looping and unnecessary rewrites. |
 | 2026-04-18 | Update Documentation & Workflows | docs/API.md, .github/workflows/ci.yml, .github/dependabot.yml | Added rate limiting section, dynamic Prisma CI check, and dependabot groups. |
 | 2026-04-19 | Client/Server Variables & AI Security | docs/ENV.md, docs/AI.md, .github/workflows/codeql.yml | Added explicit Astro SSG Client/Server env variable documentation, reinforced server-side AI key management, and enhanced CodeQL security rules. |
+| 2026-04-20 | Documentation Accuracy | README.md, docs/ARCHITECTURE.md | Corrected pnpm links/versions, documented missing scripts, and fixed tech stack package manager. |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![Built with Astro](https://img.shields.io/badge/Astro-5.16-FF5D01?style=flat&logo=astro&logoColor=white)](https://astro.build)
 [![Tailwind CSS](https://img.shields.io/badge/Tailwind-4.1-38B2AC?style=flat&logo=tailwind-css&logoColor=white)](https://tailwindcss.com)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.9-3178C6?style=flat&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
-[![npm](https://img.shields.io/badge/pnpm-8.0%2B-000000?style=flat&logo=pnpm&logoColor=white)](https://npm.sh)
+[![npm](https://img.shields.io/badge/pnpm-10.0%2B-000000?style=flat&logo=pnpm&logoColor=white)](https://pnpm.io)
 [![MDX](https://img.shields.io/badge/MDX-Enabled-1B1F24?style=flat&logo=mdx&logoColor=white)](https://mdxjs.com/)
 
 <!-- Code Quality -->
@@ -99,7 +99,7 @@ Une documentation détaillée est disponible dans le dossier `docs/` :
 ### Prérequis
 
 - Node.js 20 (Requis pour l'optimisation des images via `sharp`)
-- pnpm 8+ (Requis pour l'exécution des scripts et le gestionnaire de paquets)
+- pnpm 10 (Requis pour l'exécution des scripts et le gestionnaire de paquets)
 
 ### Installation
 
@@ -129,7 +129,9 @@ Le site sera accessible sur `http://localhost:4321`.
 - `pnpm run dev` : Optimise les images et lance le serveur de développement.
 - `pnpm run build` : Génère le build de production (avec optimisation d'images et génération CSP).
 - `pnpm run check` : Vérifie le code (linting + formatage + types).
+- `pnpm run format` : Formate le code (Prettier).
 - `pnpm run lighthouse` : Lance l'audit de performance.
+- `pnpm run analyze` : Génère le build de production et ouvre le rapport d'analyse de bundle.
 - `pnpm run test:e2e` : Lance les tests end-to-end avec Playwright.
   - `pnpm run test` : Lance les tests unitaires avec Bun.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -31,7 +31,7 @@ To add a "new endpoint" (a new page route) or "use-case", you must define the ro
 
 - **Astro 5**: Core framework.
 - **Tailwind CSS 4**: Styling engine (via Vite plugin).
-- **npm**: Package Manager.
+- **pnpm**: Package Manager.
 - **Node.js**: Runtime.
 - **Playwright**: E2E Testing.
 - **Plyr**: Video player abstraction.


### PR DESCRIPTION
- What docs changed: Corrected README.md (pnpm version 10, fixed URL to pnpm.io, added missing scripts `format` and `analyze`) and docs/ARCHITECTURE.md (corrected package manager to pnpm).
- What workflows were added/updated: Verified CI and Dependabot workflows. No changes needed to workflows as they already use Node 20 and pnpm 10 correctly.
- How to verify: Read the updated README.md and docs/ARCHITECTURE.md files.
- Notes about assumptions: Complied with Anti-Loop rules by explicitly targeting inaccurate documentation not modified in the last history entry.

---
*PR created automatically by Jules for task [9323443288729455430](https://jules.google.com/task/9323443288729455430) started by @kuasar-mknd*