### PR TITLE
🛡️ Sentinel: Add input length limits to prevent DoS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -26,3 +26,9 @@
 **Vulnerability:** A denial of service via unbounded memory consumption in Client.list() in basic-ftp version <=5.2.2. A transitive dependency coming from @lhci/cli.
 **Learning:** High-severity security vulnerabilities in deep transitive dependencies should be resolved by adding explicit version overrides in the `pnpm.overrides` section of `package.json` to satisfy security audits (e.g., `pnpm audit`).
 **Prevention:** Added `"basic-ftp": ">=5.3.0"` to the `pnpm.overrides` block in `package.json` to enforce a non-vulnerable version, preventing Denial of Service through unbounded memory growth.
+
+## 2026-04-17 - Add explicit input length limits to input validators
+
+**Vulnerability:** Denial of Service via Regular Expression Denial of Service (ReDoS) or memory exhaustion when excessively large strings are passed to regular expressions without length limits.
+**Learning:** Even well-crafted regex patterns can suffer performance degradation with extremely long inputs, and parsing/validating massive inputs consumes unnecessary CPU and memory.
+**Prevention:** Implemented strict, standards-based length limits BEFORE executing regex validation. Added `email.length > 254` (RFC 5321) to `isValidEmail` and `url.length > 2048` to `isValidUrl` as a defense-in-depth measure.

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -115,6 +115,7 @@ const EMAIL_PATTERN =
  */
 export function isValidEmail(email: string): boolean {
   if (!email || typeof email !== "string") return false;
+  if (email.length > 254) return false;
   return EMAIL_PATTERN.test(email);
 }
 
@@ -225,6 +226,7 @@ export function isValidUrl(
   } = {},
 ): boolean {
   if (!url || typeof url !== "string") return false;
+  if (url.length > 2048) return false;
 
   // 🛡️ Sentinel: Check ORIGINAL string for control characters or dangerous patterns
   // BEFORE trimming. Trimming hides trailing/leading control chars that might be malicious


### PR DESCRIPTION
🚨 Severity: MEDIUM
🎯 Cluster: Input Validation
📄 Files: src/utils/security.ts
🔐 Mitigation: Added length limits to isValidEmail (254 chars) and isValidUrl (2048 chars) to mitigate potential Regular Expression Denial of Service (ReDoS) and memory exhaustion risks when processing maliciously large strings.

---
*PR created automatically by Jules for task [6154094455991288275](https://jules.google.com/task/6154094455991288275) started by @kuasar-mknd*