### PR TITLE
🎨 Palette: Add aria-pressed state to theme toggle button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -72,3 +72,7 @@
 ## 2026-05-20 - Global Anchor Link Highlight
 **Learning:** In-page navigation via anchor links (hashes) can be disorienting as the scroll jump often happens instantaneously, leaving the user to scan the page for their intended target.
 **Action:** Implement a site-wide anchor highlight listener in the base layout that applies a temporary visual "glow" animation to any element targeted by a hash link, providing immediate visual confirmation.
+
+## 2026-04-20 - Toggle Button State Communication
+**Learning:** Toggle buttons (like the Dark/Light Mode switch) that rely purely on `aria-label` updates to communicate state changes can be less robust than standard ARIA states, especially if the `aria-label` content relies on complex text that screen readers might interpret differently.
+**Action:** When implementing a toggle button, always utilize the `aria-pressed` attribute (dynamically updating between "true" and "false") alongside `aria-label` changes to provide explicit, standardized state feedback to assistive technologies.

--- a/src/components/ui/ModeSwitch.astro
+++ b/src/components/ui/ModeSwitch.astro
@@ -9,6 +9,7 @@ import { Icon } from "astro-icon/components";
   class="theme-toggle-btn group relative ml-4 flex h-9 w-9 items-center justify-center rounded-lg bg-pacamara-primary/5 text-pacamara-secondary transition-all hover:w-40 hover:bg-pacamara-accent hover:text-white focus-visible:w-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pacamara-accent focus-visible:ring-offset-2 active:scale-95 active:duration-75 dark:bg-pacamara-white/10 dark:text-pacamara-accent dark:hover:bg-pacamara-accent dark:hover:text-white"
   aria-label="Lune (Activer le mode sombre) (Shift+T)"
   aria-keyshortcuts="Shift+T"
+  aria-pressed="false"
 >
   <div
     class="flex items-center justify-center transition-transform duration-300 group-hover:scale-110 group-focus-visible:scale-110"
@@ -126,6 +127,7 @@ import { Icon } from "astro-icon/components";
 
       for (let i = 0; i < buttons.length; i++) {
         buttons[i].setAttribute("aria-label", label);
+        buttons[i].setAttribute("aria-pressed", isDark ? "true" : "false");
       }
 
       if (announce && liveRegions.length > 0) {


### PR DESCRIPTION
💡 What: Added aria-pressed attribute to the ModeSwitch button and updated its value dynamically.
🎯 Why: Improves screen reader accessibility by providing state information indicating whether the dark theme button is currently pressed.
📸 Before/After: Visuals unchanged.
♿ Accessibility: Added aria-pressed attribute to clearly communicate toggle state to screen readers.

---
*PR created automatically by Jules for task [13604567625065029094](https://jules.google.com/task/13604567625065029094) started by @kuasar-mknd*