### PR TITLE
🎨 Palette: Wrap footer social links in nav landmark

### DIFF
--- a/src/components/common/Footer.astro
+++ b/src/components/common/Footer.astro
@@ -40,42 +40,44 @@ import { Icon } from "astro-icon/components";
 
     <!-- Column 2: Socials & Copyright (Centered) -->
     <div class="flex flex-col items-center justify-center space-y-6">
-      <ul class="flex flex-wrap justify-center gap-4">
-        {
-          config?.social?.github && (
-            <li>
-              <SocialIcon
-                url={config.social.github}
-                icon="mdi:github"
-                label="GitHub"
-              />
-            </li>
-          )
-        }
-        {
-          config?.social?.instagram && (
-            <li>
-              <SocialIcon
-                url={config.social.instagram}
-                icon="mdi:instagram"
-                label="Instagram"
-              />
-            </li>
-          )
-        }
+      <nav aria-label="Réseaux sociaux">
+        <ul class="flex flex-wrap justify-center gap-4">
+          {
+            config?.social?.github && (
+              <li>
+                <SocialIcon
+                  url={config.social.github}
+                  icon="mdi:github"
+                  label="GitHub"
+                />
+              </li>
+            )
+          }
+          {
+            config?.social?.instagram && (
+              <li>
+                <SocialIcon
+                  url={config.social.instagram}
+                  icon="mdi:instagram"
+                  label="Instagram"
+                />
+              </li>
+            )
+          }
 
-        {
-          config?.social?.youtube && (
-            <li>
-              <SocialIcon
-                url={config.social.youtube}
-                icon="mdi:youtube"
-                label="YouTube"
-              />
-            </li>
-          )
-        }
-      </ul>
+          {
+            config?.social?.youtube && (
+              <li>
+                <SocialIcon
+                  url={config.social.youtube}
+                  icon="mdi:youtube"
+                  label="YouTube"
+                />
+              </li>
+            )
+          }
+        </ul>
+      </nav>
       <div
         class="text-sm text-pacamara-primary/80 dark:text-white/80 text-center"
       >


### PR DESCRIPTION
💡 **What:**
Wrapped the unordered list of social media icons in the Footer with a semantic `<nav aria-label="Réseaux sociaux">` element.

🎯 **Why:**
Previously, the social links were just a standalone `<ul>`. By wrapping them in a `<nav>` with a descriptive `aria-label`, screen readers can now easily identify and jump to this specific section as a distinct navigation landmark, separating it from the primary site navigation.

📸 **Before/After:**
*(Visual appearance is unchanged as this is an accessibility/structural fix)*

♿ **Accessibility:**
- Added `nav` landmark role.
- Added descriptive `aria-label` ("Réseaux sociaux") to distinguish it from the main header navigation.

---
*PR created automatically by Jules for task [12946119710487303992](https://jules.google.com/task/12946119710487303992) started by @kuasar-mknd*