### PR TITLE
🎨 Palette: Add tactile feedback to pagination buttons

### DIFF
--- a/src/pages/project/[...page].astro
+++ b/src/pages/project/[...page].astro
@@ -156,7 +156,7 @@ const collectionJsonLd = {
               <a
                 id="prev-page-link"
                 href={sanitizeUrl(page.url.prev)}
-                class="group flex items-center gap-2 text-base bg-transparent border border-pacamara-secondary leading-none rounded-full py-3 px-6 text-pacamara-secondary hover:bg-pacamara-accent hover:border-pacamara-accent hover:text-pacamara-white transition-all duration-300 font-pacamara-space font-bold hover-scale-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pacamara-accent focus-visible:ring-offset-2"
+                class="group flex items-center gap-2 text-base bg-transparent border border-pacamara-secondary leading-none rounded-full py-3 px-6 text-pacamara-secondary hover:bg-pacamara-accent hover:border-pacamara-accent hover:text-pacamara-white transition-all duration-300 font-pacamara-space font-bold hover-scale-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pacamara-accent focus-visible:ring-offset-2 active:scale-95 active:duration-75"
                 aria-label={`Précédent (page ${page.currentPage - 1}) ([)`}
                 aria-keyshortcuts="["
                 data-haptic="30"
@@ -198,7 +198,7 @@ const collectionJsonLd = {
               <a
                 id="next-page-link"
                 href={sanitizeUrl(page.url.next)}
-                class="group flex items-center gap-2 text-base bg-transparent border border-pacamara-secondary leading-none rounded-full py-3 px-6 text-pacamara-secondary hover:bg-pacamara-accent hover:border-pacamara-accent hover:text-pacamara-white transition-all duration-300 font-pacamara-space font-bold hover-scale-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pacamara-accent focus-visible:ring-offset-2"
+                class="group flex items-center gap-2 text-base bg-transparent border border-pacamara-secondary leading-none rounded-full py-3 px-6 text-pacamara-secondary hover:bg-pacamara-accent hover:border-pacamara-accent hover:text-pacamara-white transition-all duration-300 font-pacamara-space font-bold hover-scale-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pacamara-accent focus-visible:ring-offset-2 active:scale-95 active:duration-75"
                 aria-label={`Suivant (page ${page.currentPage + 1}) (])`}
                 aria-keyshortcuts="]"
                 data-haptic="30"


### PR DESCRIPTION
💡 What:
Added the standard `active:scale-95 active:duration-75` Tailwind utility classes to the "Précédent" and "Suivant" pagination links on the main projects listing page.

🎯 Why:
To ensure the interactive buttons across the site provide consistent, snappy tactile feedback when clicked. Relying solely on the custom `hover-scale-sm` class without an active state made the pagination links feel less responsive than the rest of the application's primary CTAs.

📸 Before/After:
Before: Pagination links scaled up slightly on hover, but provided no visual compression feedback upon click.
After: Pagination links compress cleanly (95% scale) on click and snap back quickly (75ms duration), matching the site's micro-UX patterns.

♿ Accessibility:
No negative accessibility impacts. The visual feedback explicitly confirms user interaction (the click/press action).

---
*PR created automatically by Jules for task [7554479726606622366](https://jules.google.com/task/7554479726606622366) started by @kuasar-mknd*