### PR TITLE
🛡️ Sentinel: [security improvement] Add security headers and fix timeout memory leak in API proxy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -32,3 +32,8 @@
 **Vulnerability:** Denial of Service via Regular Expression Denial of Service (ReDoS) or memory exhaustion when excessively large strings are passed to regular expressions without length limits.
 **Learning:** Even well-crafted regex patterns can suffer performance degradation with extremely long inputs, and parsing/validating massive inputs consumes unnecessary CPU and memory.
 **Prevention:** Implemented strict, standards-based length limits BEFORE executing regex validation. Added `email.length > 254` (RFC 5321) to `isValidEmail` and `url.length > 2048` to `isValidUrl` as a defense-in-depth measure.
+
+## 2025-04-20 - Prevent Resource Exhaustion in Serverless Functions via Finally Blocks
+**Vulnerability:** Uncaught fetch exceptions or early returns leaving setTimeout callbacks pending indefinitely.
+**Learning:** In Cloudflare Workers and similar serverless environments, pending timeouts left by AbortControllers that aren't properly cleared when fetch throws an error can lead to memory leaks, concurrency limit exhaustion, or unnecessary compute time.
+**Prevention:** Always wrap fetch calls utilizing AbortController timeouts inside a `try...finally` block to ensure `clearTimeout(timeoutId)` is executed regardless of success, network failure, or other exceptions.

--- a/functions/api/submit.ts
+++ b/functions/api/submit.ts
@@ -1,5 +1,13 @@
 import { sanitizeInput, isValidEmail } from "../../src/utils/security.ts";
 
+// 🛡️ Sentinel: Centralized security headers to prevent MIME sniffing, clickjacking, and enforce HSTS
+const securityHeaders = {
+  "Content-Type": "application/json",
+  "X-Content-Type-Options": "nosniff",
+  "X-Frame-Options": "DENY",
+  "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+};
+
 export async function onRequestPost(context: {
   request: Request;
   env: { WEB3FORMS_ACCESS_KEY: string };
@@ -21,7 +29,7 @@ export async function onRequestPost(context: {
         }),
         {
           status: 403,
-          headers: { "Content-Type": "application/json" },
+          headers: securityHeaders,
         },
       );
     }
@@ -34,7 +42,7 @@ export async function onRequestPost(context: {
         JSON.stringify({ success: false, message: "Invalid JSON" }),
         {
           status: 400,
-          headers: { "Content-Type": "application/json" },
+          headers: securityHeaders,
         },
       );
     }
@@ -45,7 +53,7 @@ export async function onRequestPost(context: {
         JSON.stringify({ success: false, message: "Invalid payload format" }),
         {
           status: 400,
-          headers: { "Content-Type": "application/json" },
+          headers: securityHeaders,
         },
       );
     }
@@ -77,7 +85,7 @@ export async function onRequestPost(context: {
                 }),
                 {
                   status: 400,
-                  headers: { "Content-Type": "application/json" },
+                  headers: securityHeaders,
                 },
               );
             }
@@ -96,7 +104,7 @@ export async function onRequestPost(context: {
             }),
             {
               status: 400,
-              headers: { "Content-Type": "application/json" },
+              headers: securityHeaders,
             },
           );
         }
@@ -109,29 +117,32 @@ export async function onRequestPost(context: {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 10000);
 
-    const response = await fetch("https://api.web3forms.com/submit", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-      },
-      body: JSON.stringify(data),
-      signal: controller.signal,
-    });
-
-    clearTimeout(timeoutId);
+    let response;
+    try {
+      response = await fetch("https://api.web3forms.com/submit", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify(data),
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timeoutId);
+    }
 
     const result = await response.json();
     return new Response(JSON.stringify(result), {
       status: response.status,
-      headers: { "Content-Type": "application/json" },
+      headers: securityHeaders,
     });
   } catch {
     return new Response(
       JSON.stringify({ success: false, message: "Internal server error" }),
       {
         status: 500,
-        headers: { "Content-Type": "application/json" },
+        headers: securityHeaders,
       },
     );
   }

--- a/tests/functions/submit.test.ts
+++ b/tests/functions/submit.test.ts
@@ -4,6 +4,13 @@ import { onRequestPost } from "../../functions/api/submit.ts";
 describe("Submit Cloudflare Function", () => {
   let originalFetch: typeof fetch;
 
+  const securityHeaders = {
+    "Content-Type": "application/json",
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+    "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+  };
+
   beforeEach(() => {
     originalFetch = global.fetch;
     // Mock the global fetch to avoid real network requests
@@ -15,7 +22,7 @@ describe("Submit Cloudflare Function", () => {
         }),
         {
           status: 200,
-          headers: { "Content-Type": "application/json" },
+          headers: securityHeaders,
         },
       );
     });
@@ -73,6 +80,7 @@ describe("Submit Cloudflare Function", () => {
     const nullContext = createMockContext(null);
     const nullResponse = await onRequestPost(nullContext as unknown);
     expect(nullResponse.status).toBe(400);
+    expect(nullResponse.headers.get("X-Content-Type-Options")).toBe("nosniff");
 
     const arrayContext = createMockContext(["not", "an", "object"]);
     const arrayResponse = await onRequestPost(arrayContext as unknown);
@@ -94,6 +102,8 @@ describe("Submit Cloudflare Function", () => {
     const response = await onRequestPost(context as unknown);
 
     expect(response.status).toBe(400);
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(response.headers.get("X-Frame-Options")).toBe("DENY");
     const data = await response.json();
     expect(data.message).toBe("Bad Request: Invalid type for name");
   });
@@ -171,6 +181,8 @@ describe("Submit Cloudflare Function", () => {
     const response = await onRequestPost(context as unknown);
 
     expect(response.status).toBe(403);
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(response.headers.get("X-Frame-Options")).toBe("DENY");
     const data = await response.json();
     expect(data.success).toBe(false);
     expect(data.message).toBe("Forbidden: Invalid origin");


### PR DESCRIPTION
**🚨 Severity**: High
**💡 Vulnerability**: The `submit.ts` API proxy returned responses without fundamental security headers (like `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY`), exposing the endpoint to potential MIME sniffing and clickjacking attacks. Additionally, the `AbortController` timeout implementation failed to call `clearTimeout` if the `fetch` request threw an exception (e.g., DNS error), leaving pending timeouts alive which can lead to memory leaks and DoS (concurrency exhaustion) in serverless environments.
**🎯 Impact**: Attackers could potentially exploit missing security headers. Network failures during submission would cause the serverless worker to leak memory or hang unnecessarily due to uncleared timeout callbacks.
**🔧 Fix**: Centralized a `securityHeaders` object and applied it to all API responses. Wrapped the external `fetch` request in a robust `try...finally` block to guarantee `clearTimeout(timeoutId)` executes regardless of network exceptions. Updated unit tests to assert the presence of these headers.
**✅ Verification**: Run `pnpm test` and verify that the `tests/functions/submit.test.ts` suite passes, correctly validating the new headers and the preserved functionality.

---
*PR created automatically by Jules for task [16657009868215759051](https://jules.google.com/task/16657009868215759051) started by @kuasar-mknd*