### PR TITLE
🎨 Palette: Enhance contact form loading state UX and accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -80,3 +80,8 @@
 ## 2026-05-22 - Scroll Accessibility for Fixed Headers
 **Learning:** Fixed headers (e.g., `h-20` / 80px) often obscure the target of in-page anchor links, as the browser scrolls to the top of the viewport by default. This forces users to manually scroll up to see the targeted content.
 **Action:** Apply `scroll-pt-[header_height + buffer]` (e.g., `scroll-pt-24`) to the `<html>` element to ensure all anchor targets are cleared from the fixed header, maintaining context and accessibility.
+
+## 2024-04-21 - Form Submission Loading State Visibility & Accessibility
+
+**Learning:** When a full-width submit button enters a loading state, replacing the button text with a single, small centered spinner creates an unbalanced, ambiguous visual state. Additionally, relying on `aria-live` directly on a button that simultaneously receives `aria-busy="true"` can suppress the loading announcement for screen readers.
+**Action:** Always include descriptive text (e.g., "Envoi en cours...") alongside the spinner in the button's loading state to maintain visual weight and clarity. Use a separate, dedicated `sr-only` live region outside the button to guarantee the loading state is announced to assistive technologies.

--- a/src/components/common/ContactForm.astro
+++ b/src/components/common/ContactForm.astro
@@ -228,11 +228,11 @@ import { Icon } from "astro-icon/components";
         aria-hidden="true"
       />
       <span
-        class="btn-loading hidden absolute inset-0 items-center justify-center"
-        aria-label="Envoi en cours..."
+        class="btn-loading hidden absolute inset-0 items-center justify-center gap-2"
+        aria-hidden="true"
       >
         <svg
-          class="animate-spin h-6 w-6 text-white"
+          class="animate-spin h-5 w-5 text-white"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"
@@ -251,6 +251,7 @@ import { Icon } from "astro-icon/components";
             d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
           ></path>
         </svg>
+        <span class="font-medium">Envoi en cours...</span>
       </span>
       <span
         class="btn-success hidden absolute inset-0 items-center justify-center gap-2"
@@ -262,6 +263,15 @@ import { Icon } from "astro-icon/components";
       <!-- Ripple effect container -->
       <div class="btn-ripple absolute inset-0 pointer-events-none"></div>
     </button>
+
+    <!-- 🎨 Palette: Dedicated SR-only live region for form status updates -->
+    <div
+      id="form-status-announcer"
+      class="sr-only"
+      aria-live="polite"
+      aria-atomic="true"
+    >
+    </div>
 
     <!-- Inline Error Message -->
     <div
@@ -802,6 +812,11 @@ import { Icon } from "astro-icon/components";
           this.submitButton.setAttribute("aria-busy", "true");
         }
 
+        const announcer = document.getElementById("form-status-announcer");
+        if (announcer) {
+          announcer.textContent = "Envoi du message en cours...";
+        }
+
         try {
           const formData = new FormData(this.form);
           const data: Record<string, string> = {};
@@ -849,6 +864,12 @@ import { Icon } from "astro-icon/components";
 
             this.errorMessage?.classList.add("hidden");
             this.form.removeAttribute("aria-describedby");
+
+            const announcer = document.getElementById("form-status-announcer");
+            if (announcer) {
+              announcer.textContent = "Message envoyé avec succès.";
+            }
+
             const successMessage = document.getElementById(
               "form-success-message",
             ) as HTMLElement;
@@ -889,6 +910,12 @@ import { Icon } from "astro-icon/components";
             this.submitButton.removeAttribute("aria-disabled");
             this.submitButton.removeAttribute("aria-busy");
           }
+
+          const announcer = document.getElementById("form-status-announcer");
+          if (announcer) {
+            announcer.textContent = "";
+          }
+
           this.showError(
             isAbortError
               ? "Le serveur met trop de temps à répondre. Veuillez réessayer."


### PR DESCRIPTION
💡 What: Added text alongside the loading spinner on the ContactForm submit button and implemented a dedicated `sr-only` live region for status announcements.
🎯 Why: A single small spinner on a full-width button looks unbalanced and ambiguous. Furthermore, setting `aria-busy="true"` on a button often prevents its own `aria-live` content from being announced. The dedicated live region fixes this accessibility gap.
📸 Before/After: Visual regression verified via Playwright screenshot.
♿ Accessibility: Ensures the "Envoi en cours..." loading state is reliably communicated to assistive technologies.

---
*PR created automatically by Jules for task [14685297893853582964](https://jules.google.com/task/14685297893853582964) started by @kuasar-mknd*