### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix resource leak in contact form

### DIFF
--- a/src/components/common/ContactForm.astro
+++ b/src/components/common/ContactForm.astro
@@ -844,17 +844,21 @@ import { Icon } from "astro-icon/components";
           const timeoutId = setTimeout(() => controller.abort(), 10000);
 
           const submitUrl = "/api/submit";
-          const response = await fetch(submitUrl, {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              Accept: "application/json",
-            },
-            body: JSON.stringify(data),
-            signal: controller.signal,
-          });
+          let response;
+          try {
+            response = await fetch(submitUrl, {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                Accept: "application/json",
+              },
+              body: JSON.stringify(data),
+              signal: controller.signal,
+            });
+          } finally {
+            clearTimeout(timeoutId);
+          }
 
-          clearTimeout(timeoutId);
           const result = await response.json();
 
           if (result.success) {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `fetch` call in `src/components/common/ContactForm.astro` used an `AbortController` with a timeout, but the `clearTimeout(timeoutId)` statement was placed after the `await fetch(...)` call. If the fetch failed or threw an exception, the execution would jump to the `catch` block, skipping `clearTimeout` and leaving the timeout pending.
🎯 Impact: Leftover pending timeouts create a memory/resource leak. In environments handling many connections or retries, this can lead to memory exhaustion.
🔧 Fix: Wrapped the `fetch` call inside a `try...finally` block, ensuring that `clearTimeout(timeoutId)` is executed reliably regardless of whether the fetch succeeds or fails.
✅ Verification: Ran `pnpm test` and `pnpm lint` to ensure stability. Code review confirmed the fix is correct and introduces no regressions.

---
*PR created automatically by Jules for task [7933751870199203906](https://jules.google.com/task/7933751870199203906) started by @kuasar-mknd*