### PR TITLE
🎨 Palette: Contextual Reveal for keyboard shortcuts

### DIFF
--- a/src/components/common/Navigation.astro
+++ b/src/components/common/Navigation.astro
@@ -13,7 +13,7 @@ const currentPath = normalizePath(pathname);
       <a
         href="/"
         data-haptic="30"
-        class={`transition-all duration-300 link-animated focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pacamara-accent focus-visible:ring-offset-2 rounded-lg px-2 -mx-2 active:scale-95 active:duration-75 ${
+        class={`group transition-all duration-300 link-animated focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pacamara-accent focus-visible:ring-offset-2 rounded-lg px-2 -mx-2 active:scale-95 active:duration-75 ${
           currentPath === "/"
             ? "opacity-100 text-pacamara-accent dark:text-pacamara-accent font-medium link-active"
             : "opacity-60 text-pacamara-primary hover:opacity-100 hover:text-pacamara-accent dark:text-white dark:hover:text-pacamara-accent focus-visible:opacity-100 focus-visible:text-pacamara-accent dark:focus-visible:text-pacamara-accent"
@@ -23,7 +23,7 @@ const currentPath = normalizePath(pathname);
         aria-keyshortcuts="Alt+1"
       >
         Accueil <kbd
-          class="font-sans ml-1 opacity-70 hidden md:inline-block text-[10px] bg-pacamara-primary/5 dark:bg-white/10 px-1.5 py-0.5 rounded"
+          class="font-sans ml-1 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity duration-300 hidden md:inline-block text-[10px] bg-pacamara-primary/5 dark:bg-white/10 px-1.5 py-0.5 rounded"
           aria-hidden="true">(Alt+1)</kbd
         ></a
       >
@@ -32,7 +32,7 @@ const currentPath = normalizePath(pathname);
       <a
         href="/project/"
         data-haptic="30"
-        class={`transition-all duration-300 link-animated focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pacamara-accent focus-visible:ring-offset-2 rounded-lg px-2 -mx-2 active:scale-95 active:duration-75 ${
+        class={`group transition-all duration-300 link-animated focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pacamara-accent focus-visible:ring-offset-2 rounded-lg px-2 -mx-2 active:scale-95 active:duration-75 ${
           currentPath.startsWith("/project")
             ? "opacity-100 text-pacamara-accent dark:text-pacamara-accent font-medium link-active"
             : "opacity-60 text-pacamara-primary hover:opacity-100 hover:text-pacamara-accent dark:text-white dark:hover:text-pacamara-accent focus-visible:opacity-100 focus-visible:text-pacamara-accent dark:focus-visible:text-pacamara-accent"
@@ -42,7 +42,7 @@ const currentPath = normalizePath(pathname);
         aria-keyshortcuts="Alt+2"
       >
         Projets <kbd
-          class="font-sans ml-1 opacity-70 hidden md:inline-block text-[10px] bg-pacamara-primary/5 dark:bg-white/10 px-1.5 py-0.5 rounded"
+          class="font-sans ml-1 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity duration-300 hidden md:inline-block text-[10px] bg-pacamara-primary/5 dark:bg-white/10 px-1.5 py-0.5 rounded"
           aria-hidden="true">(Alt+2)</kbd
         ></a
       >
@@ -51,7 +51,7 @@ const currentPath = normalizePath(pathname);
       <a
         href="/about/"
         data-haptic="30"
-        class={`transition-all duration-300 link-animated focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pacamara-accent focus-visible:ring-offset-2 rounded-lg px-2 -mx-2 active:scale-95 active:duration-75 ${
+        class={`group transition-all duration-300 link-animated focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pacamara-accent focus-visible:ring-offset-2 rounded-lg px-2 -mx-2 active:scale-95 active:duration-75 ${
           currentPath === "/about"
             ? "opacity-100 text-pacamara-accent dark:text-pacamara-accent font-medium link-active"
             : "opacity-60 text-pacamara-primary hover:opacity-100 hover:text-pacamara-accent dark:text-white dark:hover:text-pacamara-accent focus-visible:opacity-100 focus-visible:text-pacamara-accent dark:focus-visible:text-pacamara-accent"
@@ -61,7 +61,7 @@ const currentPath = normalizePath(pathname);
         aria-keyshortcuts="Alt+3"
       >
         À propos <kbd
-          class="font-sans ml-1 opacity-70 hidden md:inline-block text-[10px] bg-pacamara-primary/5 dark:bg-white/10 px-1.5 py-0.5 rounded"
+          class="font-sans ml-1 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity duration-300 hidden md:inline-block text-[10px] bg-pacamara-primary/5 dark:bg-white/10 px-1.5 py-0.5 rounded"
           aria-hidden="true">(Alt+3)</kbd
         ></a
       >

--- a/src/pages/project/[...page].astro
+++ b/src/pages/project/[...page].astro
@@ -168,7 +168,7 @@ const collectionJsonLd = {
                 />
                 <span>Précédent</span>
                 <kbd
-                  class="font-sans ml-1 opacity-70 hidden sm:inline-block text-[10px] bg-pacamara-primary/5 dark:bg-white/10 px-1.5 py-0.5 rounded"
+                  class="font-sans ml-1 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity duration-300 hidden sm:inline-block text-[10px] bg-pacamara-primary/5 dark:bg-white/10 px-1.5 py-0.5 rounded"
                   aria-hidden="true"
                 >
                   [
@@ -205,7 +205,7 @@ const collectionJsonLd = {
               >
                 <span>Suivant</span>
                 <kbd
-                  class="font-sans ml-1 opacity-70 hidden sm:inline-block text-[10px] bg-pacamara-primary/5 dark:bg-white/10 px-1.5 py-0.5 rounded"
+                  class="font-sans ml-1 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity duration-300 hidden sm:inline-block text-[10px] bg-pacamara-primary/5 dark:bg-white/10 px-1.5 py-0.5 rounded"
                   aria-hidden="true"
                 >
                   ]


### PR DESCRIPTION
💡 What: Applied the "Contextual Reveal" UX pattern to keyboard shortcut hints (`<kbd>`) in the main navigation menu and pagination links. They are now visually hidden by default (`opacity-0`) and smoothly reveal themselves (`opacity-100`) on hover or keyboard focus of their parent links.
🎯 Why: Displaying keyboard shortcuts permanently clutters a minimalist UI. Revealing them contextually rewards user exploration without penalizing casual users with extra visual noise.
📸 Before/After: Visual noise reduced. Shortcuts fade in intuitively when interacting.
♿ Accessibility: Preserved the `aria-hidden="true"` attribute on the visual hints to prevent screen reader redundancy (as `aria-keyshortcuts` handles the semantic context). The visual focus state accurately transitions the visibility.

---
*PR created automatically by Jules for task [7070239751219917651](https://jules.google.com/task/7070239751219917651) started by @kuasar-mknd*