### PR TITLE
🎨 Palette: Contextual Keyboard Shortcut for Logo Navigation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -92,3 +92,7 @@
 ## 2026-04-22 - Contextual Keyboard Shortcut Reveal
 **Learning:** Displaying keyboard shortcuts (like `[` and `]`) permanently on navigation links can clutter a minimalist UI, yet they are vital for power users.
 **Action:** Use a "Contextual Reveal" pattern by setting the `<kbd>` element to `opacity-0` by default and `group-hover:opacity-100 group-focus-visible:opacity-100` with a smooth transition. This rewards exploration without penalizing casual users with extra visual noise.
+
+## 2026-05-25 - Contextual Keyboard Shortcuts for Primary Branding Links
+**Learning:** Main branding links (like the site logo) are frequently used by keyboard users to quickly navigate back to the home page, but they often lack explicit keyboard shortcuts, requiring manual tabbing.
+**Action:** Always provide explicit keyboard shortcuts (e.g., `Alt+H`) for primary navigational elements and reveal them using the consistent `<kbd>` contextual reveal pattern (`opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100`) so they are discoverable without cluttering the interface.

--- a/src/components/common/Header.astro
+++ b/src/components/common/Header.astro
@@ -34,7 +34,8 @@ const [logo1x, logo2x] = await Promise.all([
       href="/"
       class="flex items-center gap-3 group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pacamara-accent focus-visible:ring-offset-2 rounded-xl p-2 -m-2 active:scale-95 active:duration-75 transition-all"
       aria-current={Astro.url.pathname === "/" ? "page" : undefined}
-      aria-label="Samuel Dulex (Retour à l'accueil)"
+      aria-label="Samuel Dulex (Retour à l'accueil) (Alt+H)"
+      aria-keyshortcuts="Alt+H"
       data-haptic="30"
     >
       <div
@@ -60,7 +61,10 @@ const [logo1x, logo2x] = await Promise.all([
       <span
         aria-hidden="true"
         class="font-pacamara-space font-bold text-lg text-pacamara-dark dark:text-white group-hover:text-pacamara-accent group-focus-visible:text-pacamara-accent transition-colors"
-        >Samuel Dulex</span
+        >Samuel Dulex <kbd
+          class="font-sans ml-1 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity duration-300 hidden md:inline-block text-[10px] bg-pacamara-primary/5 dark:bg-white/10 px-1.5 py-0.5 rounded"
+          aria-hidden="true">(Alt+H)</kbd
+        ></span
       >
     </a>
 

--- a/src/components/common/Navigation.astro
+++ b/src/components/common/Navigation.astro
@@ -97,6 +97,9 @@ const currentPath = normalizePath(pathname);
       } else if (e.key === "3") {
         e.preventDefault();
         navigate("/about/");
+      } else if (e.key === "h" || e.key === "H") {
+        e.preventDefault();
+        navigate("/");
       }
     }
   };


### PR DESCRIPTION
**💡 What:** 
Added a global keyboard shortcut (`Alt+H`) to the primary site logo in the header, allowing users to quickly navigate back to the home page from anywhere.

**🎯 Why:**
Main branding links (like the site logo) are a primary method of returning to the home page. However, they often lack explicit keyboard shortcuts, forcing power users or keyboard-only users to manually tab back to the start of the navigation order. This provides an immediate, efficient route home.

**📸 Before/After:**
*   **Before:** The logo had an `aria-label` but no associated keyboard shortcut or visual hint.
*   **After:** The logo now responds to `Alt+H`, has an updated `aria-label`, and reveals a contextual `<kbd>` hint visually only on hover/focus to keep the interface clean.

**♿ Accessibility:**
*   Added `aria-keyshortcuts="Alt+H"` to explicitly announce the shortcut to screen readers.
*   Updated the `aria-label` to include the shortcut text.
*   Integrated into the existing keyboard event listener using `!e.ctrlKey && !e.metaKey` guards to prevent intercepting native browser actions.

---
*PR created automatically by Jules for task [14042403973046801700](https://jules.google.com/task/14042403973046801700) started by @kuasar-mknd*