### PR TITLE
🎨 Palette: Add Backspace keyboard shortcut to 404 page Back button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -51,33 +51,42 @@
 **Action:** Always leverage the centralized haptics management by simply adding the `data-haptic` attribute (e.g., `data-haptic="30"` or `data-haptic="50"`) directly to the HTML markup of the interactive element. No custom JS listeners are needed.
 
 ## 2026-04-14 - Pagination Accessibility & Navigation Context
+
 **Learning:** When adding keyboard shortcuts to pagination controls in a Single Page Application (SPA) utilizing View Transitions (like Astro's `astro:page-load`), global event listeners (like `document.addEventListener("keydown", ...)`) must be explicitly managed. They must be registered with a singleton pattern, where the previous instance is removed on subsequent page loads, otherwise memory leaks and duplicate trigger events will occur on every keystroke. Furthermore, when adding elements like `<kbd>` hints to Astro pagination controls, you must account for both active `<a>` tags and inactive boundary states, where the controls render as disabled `<span>` elements with `cursor-not-allowed` class.
 **Action:** Always test pagination components on both the first and last pages to ensure interactive styles (like hovers and keyboard shortcuts) don't apply to disabled states, and wrap global event listener additions in a cleanup check to ensure they survive SPA transitions intact.
 
 ## 2026-04-16 - Centralized Contact Form Navigation & Smart Focus
+
 **Learning:** In-page navigation to a contact form (especially from different pages or sections) can be jarring if it lacks visual feedback or causes unintended layout shifts on mobile due to automatic keyboard activation. Directing users to a form field on mobile can cover half the screen immediately, which might be undesirable if they just wanted to see the section.
 **Action:** Implement a centralized navigation handler for contact form links. Use "Smart Focus": on desktop, focus the first input to facilitate immediate typing; on mobile, focus the form container to provide visual context without triggering the virtual keyboard. Additionally, apply a temporary "highlight glow" animation to the form to clearly signal successful navigation.
+
 ## 2026-04-17 - Tactile Feedback Snappiness
+
 **Learning:** The default `transition-all duration-300` combined with `active:scale-95` creates a sluggish tactile response, as the 300ms transition delays both the scale down and the release. This reduces the perceived snappiness of interactive elements.
 **Action:** Add `active:duration-75` alongside `active:scale-95` to shorten the animation curve specifically during the active (click/press) phase, making the tactile feedback feel immediate and responsive.
 
 ## 2024-05-20 - Scaled Tactile Feedback for Large Surfaces
+
 **Learning:** Applying the standard `active:scale-95` to large interactive elements like project cards or wide CTA buttons causes an exaggerated and jarring visual distortion.
 **Action:** Use a more subtle scale factor such as `active:scale-[0.98]` for components with large surface areas to maintain snappy tactile feedback without compromising visual stability.
 
 ## 2026-04-18 - Hover Elevation Consistency
+
 **Learning:** Interactive primary and secondary CTA elements occasionally lack the tactile `hover-lift` class despite having standard press feedback (`active:scale`). This makes hover states feel inconsistent.
 **Action:** Ensure all standard CTA buttons utilize the `hover-lift` utility class to supplement base hover styles, creating a cohesive visual response.
 
 ## 2026-05-20 - Global Anchor Link Highlight
+
 **Learning:** In-page navigation via anchor links (hashes) can be disorienting as the scroll jump often happens instantaneously, leaving the user to scan the page for their intended target.
 **Action:** Implement a site-wide anchor highlight listener in the base layout that applies a temporary visual "glow" animation to any element targeted by a hash link, providing immediate visual confirmation.
 
 ## 2026-04-20 - Toggle Button State Communication
+
 **Learning:** Toggle buttons (like the Dark/Light Mode switch) that rely purely on `aria-label` updates to communicate state changes can be less robust than standard ARIA states, especially if the `aria-label` content relies on complex text that screen readers might interpret differently.
 **Action:** When implementing a toggle button, always utilize the `aria-pressed` attribute (dynamically updating between "true" and "false") alongside `aria-label` changes to provide explicit, standardized state feedback to assistive technologies.
 
 ## 2026-05-22 - Scroll Accessibility for Fixed Headers
+
 **Learning:** Fixed headers (e.g., `h-20` / 80px) often obscure the target of in-page anchor links, as the browser scrolls to the top of the viewport by default. This forces users to manually scroll up to see the targeted content.
 **Action:** Apply `scroll-pt-[header_height + buffer]` (e.g., `scroll-pt-24`) to the `<html>` element to ensure all anchor targets are cleared from the fixed header, maintaining context and accessibility.
 
@@ -85,14 +94,23 @@
 
 **Learning:** When a full-width submit button enters a loading state, replacing the button text with a single, small centered spinner creates an unbalanced, ambiguous visual state. Additionally, relying on `aria-live` directly on a button that simultaneously receives `aria-busy="true"` can suppress the loading announcement for screen readers.
 **Action:** Always include descriptive text (e.g., "Envoi en cours...") alongside the spinner in the button's loading state to maintain visual weight and clarity. Use a separate, dedicated `sr-only` live region outside the button to guarantee the loading state is announced to assistive technologies.
+
 ## 2026-05-24 - Tactile Feedback Consistency
+
 **Learning:** Applying the standard `active:scale-95` to large interactive elements like project cards or wide CTA buttons causes an exaggerated and jarring visual distortion.
 **Action:** Use a more subtle scale factor such as `active:scale-[0.98]` for components with large surface areas to maintain snappy tactile feedback without compromising visual stability. Always pair it with `active:duration-75`.
 
 ## 2026-04-22 - Contextual Keyboard Shortcut Reveal
+
 **Learning:** Displaying keyboard shortcuts (like `[` and `]`) permanently on navigation links can clutter a minimalist UI, yet they are vital for power users.
 **Action:** Use a "Contextual Reveal" pattern by setting the `<kbd>` element to `opacity-0` by default and `group-hover:opacity-100 group-focus-visible:opacity-100` with a smooth transition. This rewards exploration without penalizing casual users with extra visual noise.
 
 ## 2026-05-25 - Contextual Keyboard Shortcuts for Primary Branding Links
+
 **Learning:** Main branding links (like the site logo) are frequently used by keyboard users to quickly navigate back to the home page, but they often lack explicit keyboard shortcuts, requiring manual tabbing.
 **Action:** Always provide explicit keyboard shortcuts (e.g., `Alt+H`) for primary navigational elements and reveal them using the consistent `<kbd>` contextual reveal pattern (`opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100`) so they are discoverable without cluttering the interface.
+
+## 2024-05-26 - Keyboard Shortcut Discoverability for Navigation Actions
+
+**Learning:** Navigation buttons (like "Go back" on a 404 page) can have keyboard shortcuts added for power users, but if they are not explicitly exposed via `aria-keyshortcuts` and visual cues (like a `<kbd>` element), they remain undiscoverable.
+**Action:** When adding global keyboard shortcuts to common navigational buttons, use the established Contextual Reveal pattern for the `<kbd>` tag to provide a visual hint without cluttering the UI, and always pair it with the corresponding `aria-keyshortcuts` attribute.

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -34,6 +34,7 @@ interface Window {
   __projectFiltersInitHandler?: () => void;
   __tocInitHandler?: () => void;
   __backBtnInitHandler?: () => void;
+  __backBtnKeydownHandler?: (e: KeyboardEvent) => void;
   __navHapticsInitHandler?: () => void;
   __navKeydownHandler?: (e: KeyboardEvent) => void;
   __cvInitHandler?: () => void;

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -48,7 +48,8 @@ import { Icon } from "astro-icon/components";
       <button
         id="go-back-btn"
         class="group inline-flex items-center gap-2 bg-transparent border-2 border-pacamara-secondary text-pacamara-secondary dark:text-white font-bold py-3 px-8 rounded-full hover:bg-pacamara-secondary/10 hover-lift active:scale-[0.98] active:duration-75 transition-all duration-300 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pacamara-accent focus-visible:ring-offset-2"
-        aria-label="Retourner à la page précédente"
+        aria-label="Retourner à la page précédente (Backspace)"
+        aria-keyshortcuts="Backspace"
         data-haptic="50"
       >
         <Icon
@@ -56,7 +57,12 @@ import { Icon } from "astro-icon/components";
           class="w-5 h-5 transition-transform duration-300 group-hover:-translate-x-1 group-focus-visible:-translate-x-1"
           aria-hidden="true"
         />
-        <span aria-hidden="true">Page précédente</span>
+        <span aria-hidden="true"
+          >Page précédente<kbd
+            class="font-sans ml-2 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity duration-300 hidden sm:inline-block text-[10px] bg-pacamara-secondary/10 dark:bg-white/10 px-1.5 py-0.5 rounded"
+            >(Backspace)</kbd
+          ></span
+        >
       </button>
     </div>
   </section>
@@ -93,6 +99,41 @@ import { Icon } from "astro-icon/components";
     btn.addEventListener("click", () => {
       history.back();
     });
+
+    // 🎨 Palette: Add keyboard shortcut for Back action
+    const handleBackspace = (e: KeyboardEvent) => {
+      // Ignore if user is typing in an input
+      const target = e.target as HTMLElement;
+      if (
+        target.tagName === "INPUT" ||
+        target.tagName === "SELECT" ||
+        target.tagName === "TEXTAREA" ||
+        target.isContentEditable ||
+        e.ctrlKey ||
+        e.metaKey ||
+        e.altKey
+      ) {
+        return;
+      }
+
+      if (e.key === "Backspace") {
+        e.preventDefault();
+        // Provide haptic feedback if available and not reduced motion
+        if (
+          navigator.vibrate &&
+          !window.matchMedia("(prefers-reduced-motion: reduce)").matches
+        ) {
+          navigator.vibrate(50);
+        }
+        btn.click();
+      }
+    };
+
+    if (window.__backBtnKeydownHandler) {
+      document.removeEventListener("keydown", window.__backBtnKeydownHandler);
+    }
+    window.__backBtnKeydownHandler = handleBackspace;
+    document.addEventListener("keydown", window.__backBtnKeydownHandler);
   }
 
   // Initialize on load and after navigation (View Transitions)


### PR DESCRIPTION
💡 **What:** Added a `Backspace` keyboard shortcut to the "Page précédente" (Go back) button on the 404 error page. The shortcut is revealed contextually via a `<kbd>` element on hover/focus and explicitly exposed to screen readers via `aria-keyshortcuts="Backspace"`.
🎯 **Why:** The "Go back" action is a common navigation pattern that power users often map to a keyboard shortcut. Explicitly supporting this and providing visual cues makes the interface more discoverable and responsive to different input methods.
📸 **Before/After:** The "Page précédente" button on the 404 page now reveals a `(Backspace)` badge on hover and focus.
♿ **Accessibility:**
*   Added `aria-keyshortcuts="Backspace"` to the button for screen reader discoverability.
*   Updated `aria-label` to include the keyboard shortcut.
*   Ensured the keydown listener checks for modifier keys (`e.ctrlKey`, etc.) and ignores inputs in form fields or editable areas to prevent conflicting with native browser behaviors.
*   Added haptic feedback via `navigator.vibrate` to the keyboard shortcut execution (respecting `prefers-reduced-motion`).

---
*PR created automatically by Jules for task [4836668773467092264](https://jules.google.com/task/4836668773467092264) started by @kuasar-mknd*