### PR TITLE
🛡️ Sentinel: [security improvement] Add honeypot trap and strict CSP headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -51,3 +51,9 @@
 **Vulnerability:** Uncaught fetch exceptions or early returns leaving setTimeout callbacks pending indefinitely.
 **Learning:** In Cloudflare Workers and similar serverless environments, pending timeouts left by AbortControllers that aren't properly cleared when fetch throws an error can lead to memory leaks, concurrency limit exhaustion, or unnecessary compute time.
 **Prevention:** Always wrap fetch calls utilizing AbortController timeouts inside a `try...finally` block to ensure `clearTimeout(timeoutId)` is executed regardless of success, network failure, or other exceptions.
+
+## 2026-04-24 - Server-Side Honeypot Trap Deception
+
+**Vulnerability:** Automated spam bots repeatedly triggering API endpoints, bypassing client-side checks, and consuming downstream service quotas (e.g. Web3Forms) because they receive explicit error responses that allow them to retry or adapt.
+**Learning:** Returning explicit HTTP 400 errors or failing validation for honeypot traps allows automated bots to detect their failure and adjust their payloads or retry continuously. Deceiving them with a fake HTTP 200 OK success response is a more effective defense-in-depth strategy because it tricks the bot into believing the submission succeeded, causing them to move on without consuming actual downstream API quota.
+**Prevention:** Implement server-side honeypot validation that silently drops the malicious payload but returns a structurally identical success response to the client/bot.

--- a/functions/api/submit.ts
+++ b/functions/api/submit.ts
@@ -6,6 +6,7 @@ const securityHeaders = {
   "X-Content-Type-Options": "nosniff",
   "X-Frame-Options": "DENY",
   "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+  "Content-Security-Policy": "default-src 'none'; frame-ancestors 'none';",
 };
 
 export async function onRequestPost(context: {
@@ -60,6 +61,23 @@ export async function onRequestPost(context: {
 
     const data: Record<string, unknown> = {};
 
+    // 🛡️ Sentinel: Honeypot trap to deceive automated spam bots.
+    // If botcheck is true, silently drop the request and return a fake success response.
+    // This prevents bots from retrying and saves downstream API quota.
+    const rawDataRecord = rawData as Record<string, unknown>;
+    if (rawDataRecord.botcheck === true || rawDataRecord.botcheck === "true") {
+      return new Response(
+        JSON.stringify({
+          success: true,
+          message: "Success",
+        }),
+        {
+          status: 200,
+          headers: securityHeaders,
+        },
+      );
+    }
+
     // Define exact expected types
     const schema: Record<string, string> = {
       name: "string",
@@ -67,12 +85,12 @@ export async function onRequestPost(context: {
       message: "string",
       access_key: "string",
       subject: "string",
-      botcheck: "boolean",
       "form-load-timestamp": "string",
     };
 
     // 🛡️ Sentinel: Strict schema validation
     for (const [key, value] of Object.entries(rawData)) {
+      if (key === "botcheck") continue; // Already handled by honeypot
       const expectedType = schema[key];
       if (expectedType) {
         if (typeof value === expectedType) {


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Automated spam bots could continually trigger the form submission endpoint, consuming downstream service (Web3Forms) quota. Additionally, the proxy endpoint lacked restrictive Content-Security-Policy headers, theoretically allowing framing or direct execution if accessed via a browser context.
🎯 **Impact:** Prevents downstream API quota exhaustion via server-side deception. Hardens the API endpoint against unexpected execution contexts.
🔧 **Fix:** Added a `Content-Security-Policy: default-src 'none'; frame-ancestors 'none';` header to block loading. Intercepted the `botcheck` form payload field server-side; if truthy, the endpoint drops the payload and returns a fake HTTP 200 OK success response to deceive the bot without wasting external API limits.
✅ **Verification:** Verified by checking the proxy response headers and asserting that valid forms drop `botcheck` locally while spam inputs trigger early HTTP 200 exits. Test suite passes successfully.

---
*PR created automatically by Jules for task [16529658574890439022](https://jules.google.com/task/16529658574890439022) started by @kuasar-mknd*