### PR TITLE
🎨 Palette: Improve contact form accessibility (ARIA links and live regions)

### DIFF
--- a/src/components/common/ContactForm.astro
+++ b/src/components/common/ContactForm.astro
@@ -179,7 +179,7 @@ import { Icon } from "astro-icon/components";
           id="message"
           rows="4"
           required
-          aria-describedby="message-hint"
+          aria-describedby="message-hint message-counter message-counter-sr"
           aria-required="true"
           maxlength="5000"
           minlength="10"
@@ -219,7 +219,6 @@ import { Icon } from "astro-icon/components";
     <button
       type="submit"
       class="submit-btn cursor-pointer w-full py-4 px-6 bg-pacamara-accent hover:bg-pacamara-secondary text-white font-bold rounded-xl transition-all duration-300 shadow-lg hover:shadow-glow-accent hover-lift flex items-center justify-center gap-3 text-lg relative overflow-hidden group focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-pacamara-accent focus-visible:ring-offset-2 aria-disabled:opacity-70 aria-disabled:cursor-not-allowed aria-disabled:hover:bg-pacamara-accent aria-disabled:hover:shadow-lg aria-disabled:hover:-translate-y-0 active:scale-[0.98] active:duration-75"
-      aria-live="polite"
     >
       <span class="btn-text relative z-10">Envoyer le message</span>
       <Icon


### PR DESCRIPTION
💡 What: Fixed two accessibility issues in the contact form: added `aria-describedby` to the `<textarea>` to properly link the character counter and screen reader announcer, and removed a redundant `aria-live` attribute from the submit button.
🎯 Why: Screen reader users focusing on the textarea previously had no context for the character limit, and having `aria-live="polite"` directly on a submit button that receives `aria-busy` states can suppress announcements from the dedicated live region.
📸 Before/After: (Visual changes were limited to structural HTML enhancements; no visual screenshots necessary)
♿ Accessibility: Ensures character count limits are announced when entering the message field, and prevents conflicting ARIA live region announcements during form submission.

---
*PR created automatically by Jules for task [10649913337074211561](https://jules.google.com/task/10649913337074211561) started by @kuasar-mknd*