### PR TITLE
Home & contenu : hero épuré, `lastmod` au sitemap, ton éditorial et rôles corrigés

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,6 +8,12 @@ import { visualizer } from "rollup-plugin-visualizer";
 import tailwindcss from "@tailwindcss/vite";
 import { VitePWA } from "vite-plugin-pwa";
 
+// Date de génération du site, utilisée comme `lastmod` dans le sitemap.
+// Le portfolio est régénéré à chaque déploiement : la date de build reflète
+// donc fidèlement la dernière mise à jour et fournit à Google un signal de
+// fraîcheur pour recrawler les pages.
+const BUILD_DATE = new Date().toISOString();
+
 // https://astro.build/config
 export default defineConfig({
   trailingSlash: "always",
@@ -46,7 +52,17 @@ export default defineConfig({
       ],
     }),
   },
-  integrations: [mdx(), sitemap(), icon()],
+  integrations: [
+    mdx(),
+    sitemap({
+      // `lastmod` sur chaque URL : signal de fraîcheur pour les moteurs.
+      serialize(item) {
+        item.lastmod = BUILD_DATE;
+        return item;
+      },
+    }),
+    icon(),
+  ],
   site: "https://portfolio.kuasar.xyz",
   // Prefetch géré par Astro : tous les liens internes sont préchargés au
   // survol. Couplé à `clientPrerender`, ils sont prérendus via la Speculation

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -83,7 +83,7 @@ export default defineConfig({
           name: "Samuel Dulex | Portfolio",
           short_name: "Samuel Dulex",
           description:
-            "Portfolio de Samuel Dulex — Création de contenu, développement web & communication",
+            "Portfolio de Samuel Dulex : création de contenu, développement web & communication",
           theme_color: "#0f172a",
           background_color: "#0f172a",
           display: "standalone",

--- a/package.json
+++ b/package.json
@@ -36,12 +36,16 @@
       "undici": "^7.28.0",
       "minimatch": "^5.1.9",
       "yauzl": "^3.2.1",
-      "fast-xml-parser": ">=5.5.7",
+      "fast-xml-parser": ">=5.10.1",
       "yaml": ">=2.8.3",
       "basic-ftp": ">=5.3.1",
       "uuid": ">=14.0.0",
       "qs": ">=6.15.2",
       "tar": ">=7.5.16",
+      "body-parser": ">=1.20.6 <2.0.0",
+      "sharp": ">=0.35.0",
+      "astro-compress>svgo": ">=4.0.2",
+      "@iconify/tools>svgo": ">=3.3.4",
       "vite>esbuild": ">=0.28.1",
       "astro>esbuild": ">=0.28.1"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,12 +14,16 @@ overrides:
   undici: ^7.28.0
   minimatch: ^5.1.9
   yauzl: ^3.2.1
-  fast-xml-parser: '>=5.5.7'
+  fast-xml-parser: '>=5.10.1'
   yaml: '>=2.8.3'
   basic-ftp: '>=5.3.1'
   uuid: '>=14.0.0'
   qs: '>=6.15.2'
   tar: '>=7.5.16'
+  body-parser: '>=1.20.6 <2.0.0'
+  sharp: '>=0.35.0'
+  astro-compress>svgo: '>=4.0.2'
+  '@iconify/tools>svgo': '>=3.3.4'
   vite>esbuild: '>=0.28.1'
   astro>esbuild: '>=0.28.1'
 
@@ -103,7 +107,7 @@ importers:
         specifier: ^0.28.1
         version: 0.28.1
       sharp:
-        specifier: ^0.35.3
+        specifier: '>=0.35.0'
         version: 0.35.3(@types/node@26.1.1)
       tailwindcss:
         specifier: ^4.3.3
@@ -177,7 +181,7 @@ importers:
         version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)
       wrangler:
         specifier: ^4.112.0
-        version: 4.112.0
+        version: 4.112.0(@types/node@26.1.1)
 
 packages:
 
@@ -1312,22 +1316,10 @@ packages:
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
 
-  '@img/sharp-darwin-arm64@0.34.5':
-    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [darwin]
-
   '@img/sharp-darwin-arm64@0.35.3':
     resolution: {integrity: sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
-    os: [darwin]
-
-  '@img/sharp-darwin-x64@0.34.5':
-    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
     os: [darwin]
 
   '@img/sharp-darwin-x64@0.35.3':
@@ -1341,19 +1333,9 @@ packages:
     engines: {node: '>=20.9.0'}
     os: [freebsd]
 
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
-    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@img/sharp-libvips-darwin-arm64@1.3.2':
     resolution: {integrity: sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@img/sharp-libvips-darwin-x64@1.2.4':
-    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
-    cpu: [x64]
     os: [darwin]
 
   '@img/sharp-libvips-darwin-x64@1.3.2':
@@ -1361,21 +1343,9 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-linux-arm64@1.2.4':
-    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
   '@img/sharp-libvips-linux-arm64@1.3.2':
     resolution: {integrity: sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==}
     cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-arm@1.2.4':
-    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
-    cpu: [arm]
     os: [linux]
     libc: [glibc]
 
@@ -1385,21 +1355,9 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-ppc64@1.2.4':
-    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
   '@img/sharp-libvips-linux-ppc64@1.3.2':
     resolution: {integrity: sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==}
     cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-riscv64@1.2.4':
-    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
-    cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
@@ -1409,21 +1367,9 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-s390x@1.2.4':
-    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
   '@img/sharp-libvips-linux-s390x@1.3.2':
     resolution: {integrity: sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==}
     cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-x64@1.2.4':
-    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
-    cpu: [x64]
     os: [linux]
     libc: [glibc]
 
@@ -1433,21 +1379,9 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
     resolution: {integrity: sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==}
     cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
-    cpu: [x64]
     os: [linux]
     libc: [musl]
 
@@ -1457,24 +1391,10 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-linux-arm64@0.34.5':
-    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
   '@img/sharp-linux-arm64@0.35.3':
     resolution: {integrity: sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-arm@0.34.5':
-    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm]
     os: [linux]
     libc: [glibc]
 
@@ -1485,24 +1405,10 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-ppc64@0.34.5':
-    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
   '@img/sharp-linux-ppc64@0.35.3':
     resolution: {integrity: sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==}
     engines: {node: '>=20.9.0'}
     cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-riscv64@0.34.5':
-    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
@@ -1513,24 +1419,10 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-s390x@0.34.5':
-    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
   '@img/sharp-linux-s390x@0.35.3':
     resolution: {integrity: sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==}
     engines: {node: '>=20.9.0'}
     cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-x64@0.34.5':
-    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
     os: [linux]
     libc: [glibc]
 
@@ -1541,24 +1433,10 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linuxmusl-arm64@0.34.5':
-    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@img/sharp-linuxmusl-arm64@0.35.3':
     resolution: {integrity: sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@img/sharp-linuxmusl-x64@0.34.5':
-    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
     os: [linux]
     libc: [musl]
 
@@ -1569,11 +1447,6 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-wasm32@0.34.5':
-    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [wasm32]
-
   '@img/sharp-wasm32@0.35.3':
     resolution: {integrity: sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==}
     engines: {node: '>=20.9.0'}
@@ -1583,34 +1456,16 @@ packages:
     engines: {node: '>=20.9.0'}
     cpu: [wasm32]
 
-  '@img/sharp-win32-arm64@0.34.5':
-    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [win32]
-
   '@img/sharp-win32-arm64@0.35.3':
     resolution: {integrity: sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@img/sharp-win32-ia32@0.34.5':
-    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [ia32]
-    os: [win32]
-
   '@img/sharp-win32-ia32@0.35.3':
     resolution: {integrity: sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==}
     engines: {node: ^20.9.0}
     cpu: [ia32]
-    os: [win32]
-
-  '@img/sharp-win32-x64@0.34.5':
-    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
     os: [win32]
 
   '@img/sharp-win32-x64@0.35.3':
@@ -1674,8 +1529,8 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@nodable/entities@2.2.0':
-    resolution: {integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==}
+  '@nodable/entities@3.0.0':
+    resolution: {integrity: sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2574,8 +2429,8 @@ packages:
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
-  body-parser@1.20.4:
-    resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
+  body-parser@1.20.6:
+    resolution: {integrity: sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
   boolbase@1.0.0:
@@ -2767,10 +2622,6 @@ packages:
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
-  commander@7.2.0:
-    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
-    engines: {node: '>= 10'}
-
   common-ancestor-path@2.0.0:
     resolution: {integrity: sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==}
     engines: {node: '>= 18'}
@@ -2885,10 +2736,6 @@ packages:
   css-tree@2.2.1:
     resolution: {integrity: sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
-
-  css-tree@2.3.1:
-    resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
-    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
@@ -3365,8 +3212,8 @@ packages:
   fast-xml-builder@1.2.1:
     resolution: {integrity: sha512-tPb5TTWfgfVx5BNSi2xV0eLr89POeXXn0dXIsCJ9m1narrWxeIyx6je9d7Rce/3NyXLbvuQmLkxq+RuxMWejvw==}
 
-  fast-xml-parser@5.9.3:
-    resolution: {integrity: sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==}
+  fast-xml-parser@5.10.1:
+    resolution: {integrity: sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==}
     hasBin: true
 
   fastest-levenshtein@1.0.16:
@@ -3969,8 +3816,8 @@ packages:
   is-typedarray@1.0.0:
     resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
 
-  is-unsafe@1.0.1:
-    resolution: {integrity: sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==}
+  is-unsafe@2.0.0:
+    resolution: {integrity: sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==}
 
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
@@ -4422,9 +4269,6 @@ packages:
   mdn-data@2.0.28:
     resolution: {integrity: sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==}
 
-  mdn-data@2.0.30:
-    resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
-
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
@@ -4849,8 +4693,8 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
-  path-expression-matcher@1.6.1:
-    resolution: {integrity: sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ==}
+  path-expression-matcher@1.6.2:
+    resolution: {integrity: sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==}
     engines: {node: '>=14.0.0'}
 
   path-is-absolute@1.0.1:
@@ -5302,10 +5146,6 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
-  sharp@0.34.5:
-    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-
   sharp@0.35.3:
     resolution: {integrity: sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==}
     engines: {node: '>=20.9.0'}
@@ -5546,16 +5386,6 @@ packages:
 
   svg-tags@1.0.0:
     resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}
-
-  svgo@3.3.3:
-    resolution: {integrity: sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==}
-    engines: {node: '>=14.0.0'}
-    hasBin: true
-
-  svgo@4.0.1:
-    resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
-    engines: {node: '>=16'}
-    hasBin: true
 
   svgo@4.0.2:
     resolution: {integrity: sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==}
@@ -6294,6 +6124,10 @@ packages:
     resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
     engines: {node: '>=16.0.0'}
 
+  xml-naming@0.3.0:
+    resolution: {integrity: sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==}
+    engines: {node: '>=16.0.0'}
+
   xxhash-wasm@1.1.0:
     resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
 
@@ -6612,7 +6446,7 @@ snapshots:
 
   '@astrojs/rss@4.0.19':
     dependencies:
-      fast-xml-parser: 5.9.3
+      fast-xml-parser: 5.10.1
       piccolore: 0.1.3
       zod: 4.4.3
 
@@ -7663,7 +7497,7 @@ snapshots:
       extract-zip: 2.0.1
       local-pkg: 1.1.2
       pathe: 2.0.3
-      svgo: 3.3.3
+      svgo: 4.0.2
       tar: 7.5.19
     transitivePeerDependencies:
       - supports-color
@@ -7685,19 +7519,9 @@ snapshots:
 
   '@img/colour@1.1.0': {}
 
-  '@img/sharp-darwin-arm64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.2.4
-    optional: true
-
   '@img/sharp-darwin-arm64@0.35.3':
     optionalDependencies:
       '@img/sharp-libvips-darwin-arm64': 1.3.2
-    optional: true
-
-  '@img/sharp-darwin-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.2.4
     optional: true
 
   '@img/sharp-darwin-x64@0.35.3':
@@ -7710,69 +7534,34 @@ snapshots:
       '@img/sharp-wasm32': 0.35.3
     optional: true
 
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
-    optional: true
-
   '@img/sharp-libvips-darwin-arm64@1.3.2':
-    optional: true
-
-  '@img/sharp-libvips-darwin-x64@1.2.4':
     optional: true
 
   '@img/sharp-libvips-darwin-x64@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linux-arm64@1.2.4':
-    optional: true
-
   '@img/sharp-libvips-linux-arm64@1.3.2':
-    optional: true
-
-  '@img/sharp-libvips-linux-arm@1.2.4':
     optional: true
 
   '@img/sharp-libvips-linux-arm@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linux-ppc64@1.2.4':
-    optional: true
-
   '@img/sharp-libvips-linux-ppc64@1.3.2':
-    optional: true
-
-  '@img/sharp-libvips-linux-riscv64@1.2.4':
     optional: true
 
   '@img/sharp-libvips-linux-riscv64@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linux-s390x@1.2.4':
-    optional: true
-
   '@img/sharp-libvips-linux-s390x@1.3.2':
-    optional: true
-
-  '@img/sharp-libvips-linux-x64@1.2.4':
     optional: true
 
   '@img/sharp-libvips-linux-x64@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    optional: true
-
   '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    optional: true
-
   '@img/sharp-libvips-linuxmusl-x64@1.3.2':
-    optional: true
-
-  '@img/sharp-linux-arm64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.2.4
     optional: true
 
   '@img/sharp-linux-arm64@0.35.3':
@@ -7780,19 +7569,9 @@ snapshots:
       '@img/sharp-libvips-linux-arm64': 1.3.2
     optional: true
 
-  '@img/sharp-linux-arm@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.2.4
-    optional: true
-
   '@img/sharp-linux-arm@0.35.3':
     optionalDependencies:
       '@img/sharp-libvips-linux-arm': 1.3.2
-    optional: true
-
-  '@img/sharp-linux-ppc64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-ppc64': 1.2.4
     optional: true
 
   '@img/sharp-linux-ppc64@0.35.3':
@@ -7800,19 +7579,9 @@ snapshots:
       '@img/sharp-libvips-linux-ppc64': 1.3.2
     optional: true
 
-  '@img/sharp-linux-riscv64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-riscv64': 1.2.4
-    optional: true
-
   '@img/sharp-linux-riscv64@0.35.3':
     optionalDependencies:
       '@img/sharp-libvips-linux-riscv64': 1.3.2
-    optional: true
-
-  '@img/sharp-linux-s390x@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.2.4
     optional: true
 
   '@img/sharp-linux-s390x@0.35.3':
@@ -7820,19 +7589,9 @@ snapshots:
       '@img/sharp-libvips-linux-s390x': 1.3.2
     optional: true
 
-  '@img/sharp-linux-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.2.4
-    optional: true
-
   '@img/sharp-linux-x64@0.35.3':
     optionalDependencies:
       '@img/sharp-libvips-linux-x64': 1.3.2
-    optional: true
-
-  '@img/sharp-linuxmusl-arm64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
     optional: true
 
   '@img/sharp-linuxmusl-arm64@0.35.3':
@@ -7840,19 +7599,9 @@ snapshots:
       '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
     optional: true
 
-  '@img/sharp-linuxmusl-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-    optional: true
-
   '@img/sharp-linuxmusl-x64@0.35.3':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-x64': 1.3.2
-    optional: true
-
-  '@img/sharp-wasm32@0.34.5':
-    dependencies:
-      '@emnapi/runtime': 1.11.1
     optional: true
 
   '@img/sharp-wasm32@0.35.3':
@@ -7865,19 +7614,10 @@ snapshots:
       '@img/sharp-wasm32': 0.35.3
     optional: true
 
-  '@img/sharp-win32-arm64@0.34.5':
-    optional: true
-
   '@img/sharp-win32-arm64@0.35.3':
     optional: true
 
-  '@img/sharp-win32-ia32@0.34.5':
-    optional: true
-
   '@img/sharp-win32-ia32@0.35.3':
-    optional: true
-
-  '@img/sharp-win32-x64@0.34.5':
     optional: true
 
   '@img/sharp-win32-x64@0.35.3':
@@ -8012,7 +7752,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@nodable/entities@2.2.0': {}
+  '@nodable/entities@3.0.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -8755,8 +8495,8 @@ snapshots:
       html-minifier-terser: 7.2.0
       kleur: 4.1.5
       lightningcss: 1.32.0
-      sharp: 0.34.5
-      svgo: 4.0.1
+      sharp: 0.35.3(@types/node@26.1.1)
+      svgo: 4.0.2
       terser: 5.46.1
     transitivePeerDependencies:
       - '@astrojs/markdown-remark'
@@ -9102,7 +8842,7 @@ snapshots:
 
   blake3-wasm@2.1.5: {}
 
-  body-parser@1.20.4:
+  body-parser@1.20.6:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
@@ -9328,8 +9068,6 @@ snapshots:
 
   commander@2.20.3: {}
 
-  commander@7.2.0: {}
-
   common-ancestor-path@2.0.0: {}
 
   common-tags@1.8.2: {}
@@ -9439,11 +9177,6 @@ snapshots:
   css-tree@2.2.1:
     dependencies:
       mdn-data: 2.0.28
-      source-map-js: 1.2.1
-
-  css-tree@2.3.1:
-    dependencies:
-      mdn-data: 2.0.30
       source-map-js: 1.2.1
 
   css-tree@3.2.1:
@@ -9959,7 +9692,7 @@ snapshots:
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
-      body-parser: 1.20.4
+      body-parser: 1.20.6
       content-disposition: 0.5.4
       content-type: 1.0.5
       cookie: 0.7.2
@@ -10041,17 +9774,17 @@ snapshots:
 
   fast-xml-builder@1.2.1:
     dependencies:
-      path-expression-matcher: 1.6.1
+      path-expression-matcher: 1.6.2
       xml-naming: 0.1.0
 
-  fast-xml-parser@5.9.3:
+  fast-xml-parser@5.10.1:
     dependencies:
-      '@nodable/entities': 2.2.0
+      '@nodable/entities': 3.0.0
       fast-xml-builder: 1.2.1
-      is-unsafe: 1.0.1
-      path-expression-matcher: 1.6.1
+      is-unsafe: 2.0.0
+      path-expression-matcher: 1.6.2
       strnum: 2.4.1
-      xml-naming: 0.1.0
+      xml-naming: 0.3.0
 
   fastest-levenshtein@1.0.16: {}
 
@@ -10764,7 +10497,7 @@ snapshots:
 
   is-typedarray@1.0.0: {}
 
-  is-unsafe@1.0.1: {}
+  is-unsafe@2.0.0: {}
 
   is-weakmap@2.0.2: {}
 
@@ -11298,8 +11031,6 @@ snapshots:
 
   mdn-data@2.0.28: {}
 
-  mdn-data@2.0.30: {}
-
   mdn-data@2.27.1: {}
 
   media-typer@0.3.0: {}
@@ -11595,15 +11326,16 @@ snapshots:
 
   mimic-fn@1.2.0: {}
 
-  miniflare@4.20260714.0:
+  miniflare@4.20260714.0(@types/node@26.1.1):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
-      sharp: 0.34.5
+      sharp: 0.35.3(@types/node@26.1.1)
       undici: 7.28.0
       workerd: 1.20260714.1
       ws: 8.21.0
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
+      - '@types/node'
       - bufferutil
       - utf-8-validate
 
@@ -11886,7 +11618,7 @@ snapshots:
 
   path-exists@4.0.0: {}
 
-  path-expression-matcher@1.6.1: {}
+  path-expression-matcher@1.6.2: {}
 
   path-is-absolute@1.0.1: {}
 
@@ -12465,37 +12197,6 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  sharp@0.34.5:
-    dependencies:
-      '@img/colour': 1.1.0
-      detect-libc: 2.1.2
-      semver: 7.8.5
-    optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.34.5
-      '@img/sharp-darwin-x64': 0.34.5
-      '@img/sharp-libvips-darwin-arm64': 1.2.4
-      '@img/sharp-libvips-darwin-x64': 1.2.4
-      '@img/sharp-libvips-linux-arm': 1.2.4
-      '@img/sharp-libvips-linux-arm64': 1.2.4
-      '@img/sharp-libvips-linux-ppc64': 1.2.4
-      '@img/sharp-libvips-linux-riscv64': 1.2.4
-      '@img/sharp-libvips-linux-s390x': 1.2.4
-      '@img/sharp-libvips-linux-x64': 1.2.4
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-      '@img/sharp-linux-arm': 0.34.5
-      '@img/sharp-linux-arm64': 0.34.5
-      '@img/sharp-linux-ppc64': 0.34.5
-      '@img/sharp-linux-riscv64': 0.34.5
-      '@img/sharp-linux-s390x': 0.34.5
-      '@img/sharp-linux-x64': 0.34.5
-      '@img/sharp-linuxmusl-arm64': 0.34.5
-      '@img/sharp-linuxmusl-x64': 0.34.5
-      '@img/sharp-wasm32': 0.34.5
-      '@img/sharp-win32-arm64': 0.34.5
-      '@img/sharp-win32-ia32': 0.34.5
-      '@img/sharp-win32-x64': 0.34.5
-
   sharp@0.35.3(@types/node@26.1.1):
     dependencies:
       '@img/colour': 1.1.0
@@ -12832,26 +12533,6 @@ snapshots:
   supports-preserve-symlinks-flag@1.0.0: {}
 
   svg-tags@1.0.0: {}
-
-  svgo@3.3.3:
-    dependencies:
-      commander: 7.2.0
-      css-select: 5.2.2
-      css-tree: 2.3.1
-      css-what: 6.2.2
-      csso: 5.0.5
-      picocolors: 1.1.1
-      sax: 1.6.0
-
-  svgo@4.0.1:
-    dependencies:
-      commander: 11.1.0
-      css-select: 5.2.2
-      css-tree: 3.2.1
-      css-what: 6.2.2
-      csso: 5.0.5
-      picocolors: 1.1.1
-      sax: 1.6.0
 
   svgo@4.0.2:
     dependencies:
@@ -13571,19 +13252,20 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260714.1
       '@cloudflare/workerd-windows-64': 1.20260714.1
 
-  wrangler@4.112.0:
+  wrangler@4.112.0(@types/node@26.1.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260714.1)
       blake3-wasm: 2.1.5
       esbuild: 0.28.1
-      miniflare: 4.20260714.0
+      miniflare: 4.20260714.0(@types/node@26.1.1)
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
       workerd: 1.20260714.1
     optionalDependencies:
       fsevents: 2.3.3
     transitivePeerDependencies:
+      - '@types/node'
       - bufferutil
       - utf-8-validate
 
@@ -13632,6 +13314,8 @@ snapshots:
   xdg-basedir@4.0.0: {}
 
   xml-naming@0.1.0: {}
+
+  xml-naming@0.3.0: {}
 
   xxhash-wasm@1.1.0: {}
 

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,5 +1,5 @@
 # Redirections 301 : les projets vivaient historiquement à la racine ET sous /project/.
-# La route racine (src/pages/[slug].astro) a été supprimée — on préserve les anciens liens.
+# La route racine (src/pages/[slug].astro) a été supprimée, on préserve les anciens liens.
 /48h-geneve-2024 /project/48h-geneve-2024/ 301
 /48h-geneve-2024/ /project/48h-geneve-2024/ 301
 /48h-geneve-2025 /project/48h-geneve-2025/ 301

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,4 +1,4 @@
-# Samuel Dulex — Portfolio
+# Samuel Dulex, Portfolio
 
 > Créateur hybride basé à Lausanne, Suisse romande. Trois piliers :
 > création de contenu (vidéo, photographie), développement web
@@ -17,7 +17,7 @@
 ## Services proposés
 
 - Création de contenu : clips, courts-métrages, reportages, photographie de plateau et d'événement
-- Développement web : sites, applications et plateformes — performants, accessibles, sécurisés
+- Développement web : sites, applications et plateformes, performants, accessibles, sécurisés
 - Communication : stratégie, campagnes, relations presse et promotion d'événements
 
 ## Informations de contact
@@ -35,11 +35,11 @@
 
 ## Projets notables
 
-- [La Paternelle](https://portfolio.kuasar.xyz/project/paternelle/): Responsable communication depuis 2019 — 8 000 spectateurs par édition au Théâtre de Beaulieu (Lausanne), édition 2025 à guichets fermés
-- [CHUV — blocs opératoires](https://portfolio.kuasar.xyz/project/chuv-blocs-operatoires/): Travail de bachelor HEIG-VD 2024 — UX research et conception d'une application mobile pour l'installation des équipements biomédicaux
+- [La Paternelle](https://portfolio.kuasar.xyz/project/paternelle/): Responsable communication depuis 2019, 8 000 spectateurs par édition au Théâtre de Beaulieu (Lausanne), édition 2025 à guichets fermés
+- [CHUV, blocs opératoires](https://portfolio.kuasar.xyz/project/chuv-blocs-operatoires/): Travail de bachelor HEIG-VD 2024, UX research et conception d'une application mobile pour l'installation des équipements biomédicaux
 - [Portfolio kuasar.xyz](https://portfolio.kuasar.xyz/project/portfolio-kuasar/): Conception et développement de ce site (Astro, TypeScript, score Lighthouse 100 en performance)
-- [Songe — 48H Genève 2024](https://portfolio.kuasar.xyz/project/48h-geneve-2024/): Prix du Meilleur Film, rôle électro, DIT et photographe de plateau
-- [Après l'averse. — 48H Lausanne 2024](https://portfolio.kuasar.xyz/project/48h-lausanne-2024/): Prix de la Meilleure Image, rôle électro, machiniste et DIT
+- [Songe, 48H Genève 2024](https://portfolio.kuasar.xyz/project/48h-geneve-2024/): Prix du Meilleur Film, rôle électro, DIT et photographe de plateau
+- [Après l'averse., 48H Lausanne 2024](https://portfolio.kuasar.xyz/project/48h-lausanne-2024/): Prix de la Meilleure Image, rôle électro, machiniste et DIT
 - [YouPlantes](https://portfolio.kuasar.xyz/project/youplantes/): Stratégie et conception d'une boutique e-commerce WooCommerce (HEIG-VD)
 
 ## Faits vérifiables

--- a/src/components/features/home/Hero.astro
+++ b/src/components/features/home/Hero.astro
@@ -1,69 +1,15 @@
 ---
 import { getImage } from "astro:assets";
-import type { CollectionEntry } from "astro:content";
-import type { ImageMetadata } from "astro";
 import { Icon } from "astro-icon/components";
 import logo from "../../../assets/logo.avif";
-import { limitConcurrency } from "../../../utils/async";
-import { getSortedProjects } from "../../../utils/projects";
-import { selectFeaturedBalanced } from "../../../utils/featured";
 import BackgroundAnimation from "./BackgroundAnimation.astro";
-
-interface Props {
-  projects?: CollectionEntry<"project">[];
-}
-
-const { projects: initialProjects } = Astro.props;
-
-// Fetch all project images
-const projects = initialProjects || (await getSortedProjects());
-
-// Sélection éditoriale : projets `featured` en alternant les piliers,
-// au lieu d'un tirage aléatoire qui sur-représentait la vidéo.
-const limit = Math.min(15, projects.length);
-const slides: { src: ImageMetadata | undefined; alt: string }[] =
-  selectFeaturedBalanced(projects, limit).map((project) => ({
-    src: project.data.image,
-    alt: project.data.title,
-  }));
-
-// ⚡ Bolt: Optimize carousel images
-// Pre-generate optimized WebP assets to avoid using <Picture> (which creates multiple <source> tags).
-// Use WebP (98% support) instead of AVIF (93%) to ensure compatibility while maintaining
-// the performance benefits of a single <img> tag.
-// This reduces DOM nodes in the carousel by ~66% (from ~90 to ~30 nodes).
-// ⚡ Bolt: Limit concurrency to 2 slides to prevent build OOM on Render
-const optimizedSlides = await limitConcurrency(slides, 2, async (slide) => {
-  if (!slide.src) return null; // Safe guard for optional image
-
-  // Generate candidates for srcset matching the original Picture configuration
-  const [w224, w288, w448, w576] = await Promise.all([
-    getImage({ src: slide.src, width: 224, format: "webp", quality: 80 }),
-    getImage({ src: slide.src, width: 288, format: "webp", quality: 80 }),
-    getImage({ src: slide.src, width: 448, format: "webp", quality: 80 }),
-    getImage({ src: slide.src, width: 576, format: "webp", quality: 80 }),
-  ]);
-
-  return {
-    alt: slide.alt,
-    src: w288.src, // Default src
-    srcset: `${w224.src} 224w, ${w288.src} 288w, ${w448.src} 448w, ${w576.src} 576w`,
-    sizes: "(max-width: 768px) 224px, 288px",
-  };
-});
-
-const validOptimizedSlides = optimizedSlides.filter((s) => s !== null);
-
-// ⚡ Bolt: Duplicate slides for seamless infinite scroll
-// Limited to 15 unique items (30 total) to cap DOM nodes and memory usage
-const allSlides = [...validOptimizedSlides, ...validOptimizedSlides];
 
 // ⚡ Bolt: Precompute LCP image URL to match Base.astro preload exactly
 const optimizedLogo = await getImage({ src: logo, width: 360, format: "avif" });
 ---
 
 <section
-  class="relative overflow-hidden min-h-[90vh] flex flex-col justify-center items-center pt-20 pb-10"
+  class="relative overflow-hidden min-h-[90vh] flex flex-col justify-center items-center pt-20 pb-16"
 >
   <!-- Background Glows -->
   <BackgroundAnimation />
@@ -142,39 +88,6 @@ const optimizedLogo = await getImage({ src: logo, width: 360, format: "avif" });
       </a>
     </div>
   </div>
-
-  <!-- Infinite Scroll Carousel -->
-  <div
-    class="w-full mt-16 overflow-hidden hero-carousel touch-carousel contain-layout-paint"
-    id="hero-carousel"
-  >
-    <div class="infinite-scroll py-8 pb-12 duration-120s" id="carousel-track">
-      {/* Duplicate slides for seamless infinite scroll */}
-      {
-        allSlides.map((slide, index) => (
-          <div
-            class="relative w-56 md:w-72 aspect-9-16 flex-none rounded-2xl overflow-hidden shadow-glass mx-3 hover:scale-105 focus-visible:scale-105 transition-transform duration-500 image-zoom"
-            style={`transform: rotate(${(index % 5) * 3 - 6}deg)`}
-          >
-            {/* ⚡ Bolt: Replaced <Picture> with <img> to reduce DOM nodes during animation */}
-            <img
-              src={slide.src}
-              srcset={slide.srcset}
-              sizes={slide.sizes}
-              alt={slide.alt}
-              width="288"
-              height="320"
-              class="object-cover w-full h-full"
-              loading={index < 3 ? "eager" : "lazy"}
-              decoding="async"
-              fetchpriority={index < 3 ? "high" : "low"}
-            />
-            <div class="absolute inset-0 bg-linear-to-t from-black/40 via-transparent to-transparent opacity-0 hover:opacity-100 focus-visible:opacity-100 transition-opacity duration-300" />
-          </div>
-        ))
-      }
-    </div>
-  </div>
 </section>
 
 <style>
@@ -202,11 +115,6 @@ const optimizedLogo = await getImage({ src: logo, width: 360, format: "avif" });
     animation: fade-slide-up 0.8s cubic-bezier(0.16, 1, 0.3, 1) 0.9s forwards;
   }
 
-  .hero-carousel {
-    opacity: 0;
-    animation: fade-slide-up 0.8s cubic-bezier(0.16, 1, 0.3, 1) 1s forwards;
-  }
-
   @keyframes fade-slide-up {
     0% {
       opacity: 0;
@@ -218,209 +126,13 @@ const optimizedLogo = await getImage({ src: logo, width: 360, format: "avif" });
     }
   }
 
-  /* Gradient mask for carousel edges */
-  .hero-carousel {
-    mask-image: linear-gradient(
-      to right,
-      transparent 0%,
-      black 10%,
-      black 90%,
-      transparent 100%
-    );
-    -webkit-mask-image: linear-gradient(
-      to right,
-      transparent 0%,
-      black 10%,
-      black 90%,
-      transparent 100%
-    );
-  }
-
-  /* Draggable carousel for both touch and mouse */
-  .touch-carousel {
-    cursor: grab;
-    /* Prevent text selection while dragging */
-    user-select: none;
-    -webkit-user-select: none;
-  }
-
-  .touch-carousel:active {
-    cursor: grabbing;
-  }
-
   /* Reduced motion */
   @media (prefers-reduced-motion: reduce) {
     .hero-logo,
     .hero-subtitle,
-    .hero-buttons,
-    .hero-carousel {
+    .hero-buttons {
       opacity: 1;
       animation: none;
     }
   }
 </style>
-
-<script>
-  /**
-   * ⚡ Bolt: Carousel Touch Optimization
-   * Added initialization guard and passive listeners to all touch events
-   */
-  function initCarouselTouch() {
-    const carousel = document.getElementById("hero-carousel");
-    const track = document.getElementById("carousel-track");
-
-    // ⚡ Early return guards
-    if (!carousel || !track) return;
-    if (carousel.dataset.touchInitialized === "true") return;
-    carousel.dataset.touchInitialized = "true";
-
-    let isDragging = false;
-    let hasDragged = false;
-    let startX = 0;
-    let currentTranslate = 0;
-    let rafId: number | null = null;
-    let lastX = 0;
-
-    const handleDragStart = (clientX: number) => {
-      isDragging = true;
-      hasDragged = false;
-      startX = clientX;
-      track.style.animationPlayState = "paused";
-      const computedStyle = getComputedStyle(track);
-      const matrix = new DOMMatrix(computedStyle.transform);
-      currentTranslate = matrix.m41;
-    };
-
-    const handleDragMove = (clientX: number) => {
-      if (!isDragging) return;
-      lastX = clientX;
-      const diff = lastX - startX;
-
-      // Only consider it a drag if moved more than 5px
-      if (Math.abs(diff) > 5) {
-        hasDragged = true;
-      }
-
-      if (!rafId && hasDragged) {
-        rafId = requestAnimationFrame(() => {
-          track.style.transform = `translateX(${currentTranslate + diff}px)`;
-          rafId = null;
-        });
-      }
-    };
-
-    const handleDragEnd = () => {
-      if (!isDragging) return;
-      isDragging = false;
-      if (rafId) {
-        cancelAnimationFrame(rafId);
-        rafId = null;
-      }
-      track.style.transform = "";
-      track.style.animationPlayState = "running";
-    };
-
-    // Prevent click events from firing if we actually dragged
-    carousel.addEventListener(
-      "click",
-      (e) => {
-        if (hasDragged) {
-          e.preventDefault();
-          e.stopPropagation();
-          hasDragged = false;
-        }
-      },
-      { capture: true },
-    );
-
-    // Touch Events
-    carousel.addEventListener(
-      "touchstart",
-      (e) => handleDragStart(e.touches[0].clientX),
-      { passive: true },
-    );
-    carousel.addEventListener(
-      "touchmove",
-      (e) => handleDragMove(e.touches[0].clientX),
-      { passive: true },
-    );
-    carousel.addEventListener("touchend", handleDragEnd, { passive: true });
-    carousel.addEventListener("touchcancel", handleDragEnd, { passive: true });
-
-    // Mouse Events
-    carousel.addEventListener("mousedown", (e) => {
-      handleDragStart(e.clientX);
-    });
-    carousel.addEventListener("mousemove", (e) => {
-      if (isDragging) {
-        e.preventDefault(); // Prevent text selection ONLY when actively dragging
-        handleDragMove(e.clientX);
-      }
-    });
-    carousel.addEventListener("mouseup", handleDragEnd);
-    carousel.addEventListener("mouseleave", handleDragEnd);
-  }
-
-  /**
-   * ⚡ Bolt: Carousel Visibility Optimization
-   * Pauses the infinite scroll animation when the carousel is not in the viewport
-   * to save GPU and main thread resources.
-   */
-  function initCarouselObserver() {
-    if (window.__carouselObserver) {
-      window.__carouselObserver.disconnect();
-      window.__carouselObserver = null;
-    }
-
-    const carousel = document.getElementById("hero-carousel");
-    const track = document.getElementById("carousel-track");
-
-    if (!carousel || !track) return;
-
-    window.__carouselObserver = new IntersectionObserver(
-      (entries) => {
-        // ⚡ Bolt: Optimized forEach loop into a standard for loop to avoid array callback allocation.
-        for (let i = 0; i < entries.length; i++) {
-          const entry = entries[i];
-          if (entry.isIntersecting) {
-            track.style.animationPlayState = "running";
-          } else {
-            track.style.animationPlayState = "paused";
-          }
-        }
-      },
-      { rootMargin: "200px" },
-    ); // Pre-load animation slightly before it enters viewport
-
-    window.__carouselObserver.observe(carousel);
-  }
-
-  // ⚡ Bolt: Cleanup observer on navigation to prevent memory leaks
-  document.addEventListener("astro:before-swap", () => {
-    if (window.__carouselObserver) {
-      window.__carouselObserver.disconnect();
-      window.__carouselObserver = null;
-    }
-  });
-
-  // ⚡ Bolt: Singleton Listener Pattern
-  // Consolidates initialization logic and prevents listener accumulation
-  function setupHeroListeners() {
-    const initAll = () => {
-      initCarouselTouch();
-      initCarouselObserver();
-    };
-
-    if (window.__heroInitHandler) {
-      document.removeEventListener("astro:page-load", window.__heroInitHandler);
-    }
-
-    window.__heroInitHandler = initAll;
-    document.addEventListener("astro:page-load", initAll);
-
-    // Run immediately for current execution
-    initAll();
-  }
-
-  setupHeroListeners();
-</script>

--- a/src/components/features/projects/LatestPosts.astro
+++ b/src/components/features/projects/LatestPosts.astro
@@ -15,7 +15,7 @@ interface Props {
   subtitle?: string;
   lazyLoadImages?: boolean;
   allPosts?: CollectionEntry<"project">[];
-  posts?: CollectionEntry<"project">[]; // sélection pré-calculée (ex. featured équilibrés) — court-circuite le tri par date
+  posts?: CollectionEntry<"project">[]; // sélection pré-calculée (ex. featured équilibrés), court-circuite le tri par date
 }
 
 const {

--- a/src/components/features/projects/ProjectFilter.astro
+++ b/src/components/features/projects/ProjectFilter.astro
@@ -1,6 +1,6 @@
 ---
 // Filtres par pilier éditorial (Création de contenu / Développement web /
-// Communication) — remplace l'ancien nuage de tags libres.
+// Communication), remplace l'ancien nuage de tags libres.
 import { PILLARS } from "../../../utils/pillars";
 import { sanitizeUrl } from "../../../utils/security";
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -12,7 +12,7 @@ const authorCollection = defineCollection({
     }),
 });
 
-// Piliers éditoriaux du portfolio — pilotent les filtres, l'équilibre de la
+// Piliers éditoriaux du portfolio : pilotent les filtres, l'équilibre de la
 // home et (à terme) les pages services. Complémentaire de `type` qui ne
 // détermine que le média affiché (player vidéo vs galerie).
 export const PROJECT_CATEGORIES = [

--- a/src/content/project/48h-geneve-2024.mdx
+++ b/src/content/project/48h-geneve-2024.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Électro & DIT sur Songe — Meilleur Film, 48H Genève 2024"
+title: "Électro & DIT sur Songe (Meilleur Film, 48H Genève 2024)"
 pubDate: 2024-10-27
 intro: "Songe a remporté le Prix du Meilleur Film du 48H Film Project Genève 2024. Sur ce tournage marathon, j'ai assuré la lumière (électro), la gestion des données (DIT) et la photographie de plateau."
 seoDescription: "Découvrez les coulisses du court-métrage Songe, réalisé pour le 48H Film Project Genève 2024. Rôle : Electro, DIT et Photographe de plateau."
@@ -9,11 +9,12 @@ image: "../../assets/48h-geneve-3.avif"
 type: video
 videoUrl: https://vimeo.com/1091205621
 category: "video"
+secondaryCategories: ["photo"]
 role: "Électro, DIT & photographe de plateau"
 client: "48H Film Project Genève"
 featured: 90
 awards:
-  - "Prix du Meilleur Film — 48H Film Project Genève 2024"
+  - "Prix du Meilleur Film, 48H Film Project Genève 2024"
 ---
 
 import { Image } from "astro:assets";

--- a/src/content/project/48h-geneve-2025.mdx
+++ b/src/content/project/48h-geneve-2025.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Gaffer sur Gamines — court-métrage primé, 48H Genève 2025"
+title: "Gaffer sur Gamines (court-métrage primé, 48H Genève 2025)"
 pubDate: 2025-10-18
 intro: "Chef électricien (gaffer) sur Gamines, court-métrage primé du 48H Film Project Genève 2025 : deux sœurs s'isolent dans une forêt d'automne, et le deuil partagé tourne au tribunal."
 seoDescription: "Gamines, court-métrage réalisé pour le 48h de Genève 2025. Gaffer sur ce projet primé."
@@ -13,7 +13,7 @@ role: "Gaffer"
 client: "48H Film Project Genève"
 featured: 82
 awards:
-  - "Court-métrage primé — 48H Genève 2025"
+  - "Court-métrage primé, 48H Genève 2025"
 ---
 
 import ImageGallery from "../../components/ui/ImageGallery.astro";

--- a/src/content/project/48h-lausanne-2024.mdx
+++ b/src/content/project/48h-lausanne-2024.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Électro & machiniste sur Après l'averse. — Meilleure Image, 48H Lausanne 2024"
+title: "Électro & machiniste sur Après l'averse. (Meilleure Image, 48H Lausanne 2024)"
 pubDate: 2024-09-27
-intro: "Après l'averse. a reçu le Prix de la Meilleure Image au 48H Film Project Lausanne 2024. J'y ai tenu les postes d'électro, de machiniste et de DIT — 48 heures pour écrire, tourner et monter un film."
+intro: "Après l'averse. a reçu le Prix de la Meilleure Image au 48H Film Project Lausanne 2024. J'y ai tenu les postes d'électro, de machiniste et de DIT : 48 heures pour écrire, tourner et monter un film."
 seoDescription: "Découvrez les coulisses de 'Après l'averse.', court-métrage réalisé pour le 48H Film Project Lausanne 2024. Rôle : Electro, Machiniste et DIT."
 tag: court-métrage
 author: samuel
@@ -13,7 +13,7 @@ role: "Électro, machiniste & DIT"
 client: "48H Film Project Lausanne"
 featured: 84
 awards:
-  - "Prix de la Meilleure Image — 48H Film Project Lausanne 2024"
+  - "Prix de la Meilleure Image, 48H Film Project Lausanne 2024"
 ---
 
 import { Image } from "astro:assets";

--- a/src/content/project/48h-vevey-2025.mdx
+++ b/src/content/project/48h-vevey-2025.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Préproduction & logistique sur Bruit Blanc — VIFFF 2025"
+title: "Préproduction & logistique sur Bruit Blanc (VIFFF 2025)"
 pubDate: 2025-09-27
 intro: "Pour le concours Tournez court ! du VIFFF (Vevey), j'ai assuré la préproduction et la logistique de Bruit Blanc : un court-métrage écrit, tourné et monté en 48 heures sur le thème de l'utopie."
 seoDescription: "Court-métrage réalisé pour le concours Tournez court ! du VIFFF 2025. Thème : Utopie."
@@ -13,7 +13,7 @@ gallery:
   - "../../assets/48h-vevey/_MG_8941.avif"
 category: "video"
 role: "Préproduction & logistique de tournage"
-client: "VIFFF — Tournez court !"
+client: "VIFFF (Tournez court !)"
 featured: 0
 ---
 

--- a/src/content/project/appy.mdx
+++ b/src/content/project/appy.mdx
@@ -1,8 +1,8 @@
 ---
-title: "APPY — application ludique de découverte d'Yverdon-les-Bains"
+title: "APPY, application ludique de découverte d'Yverdon-les-Bains"
 pubDate: 2024-05-31
-intro: "Projet interdisciplinaire mené à 13 pour la ville d'Yverdon-les-Bains : une application mobile familiale qui fait découvrir la ville par des parcours contés en QR codes, avec deux héros — Violette la Castorette et Brumus le sorcier — et des récompenses chez les commerçants locaux."
-seoDescription: "Étude de cas : APPY, application mobile familiale de découverte d'Yverdon-les-Bains par parcours contés — UX, storytelling, branding et marketing (HEIG-VD)."
+intro: "Projet interdisciplinaire mené à 13 pour la ville d'Yverdon-les-Bains : une application mobile familiale qui fait découvrir la ville par des parcours contés en QR codes, avec deux héros (Violette la Castorette et Brumus le sorcier) et des récompenses chez les commerçants locaux."
+seoDescription: "Étude de cas : APPY, application mobile familiale de découverte d'Yverdon-les-Bains par parcours contés. UX, storytelling, branding et marketing (HEIG-VD)."
 tag: "design produit"
 author: "samuel"
 image: "../../assets/appy/carte-parcours.avif"
@@ -12,7 +12,7 @@ category: "web"
 secondaryCategories:
   - "communication"
   - "video"
-role: "Chef de projet — coordination & gestion (équipe de 13)"
+role: "Chef de projet : coordination & gestion (équipe de 13)"
 client: "Ville d'Yverdon-les-Bains"
 figmaUrl: "https://www.figma.com/file/vqRj0CRQy1yHd74vzSTLpZ/Cr%C3%A9ation-de-parcours?type=whiteboard&node-id=0-1&t=JR73IKbvNTD13LsP-0"
 featured: 82
@@ -36,11 +36,11 @@ metrics:
 
 import ImageGallery from "../../components/ui/ImageGallery.astro";
 
-**APPY** est le projet interdisciplinaire (module « Projet Intermédiaire ») de 3ᵉ année du bachelor en Ingénierie des médias de la **HEIG-VD** : une équipe de **13 personnes** et une mandante réelle, la ville d'**Yverdon-les-Bains**. La commande — revitaliser l'image de la ville et promouvoir ses atouts auprès d'un jeune public. Un projet résolument transverse, à la croisée du **développement, de l'UX, de la création de contenu, de la communication et du marketing** — que nous avons mené comme une véritable agence, de la recherche utilisateur jusqu'au dossier stratégique remis à la ville.
+**APPY** est le projet interdisciplinaire (module « Projet Intermédiaire ») de 3ᵉ année du bachelor en Ingénierie des médias de la **HEIG-VD** : une équipe de **13 personnes** et une mandante réelle, la ville d'**Yverdon-les-Bains**. La commande : revitaliser l'image de la ville et promouvoir ses atouts auprès d'un jeune public. Un projet résolument transverse, à la croisée du **développement, de l'UX, de la création de contenu, de la communication et du marketing**, que nous avons mené comme une véritable agence, de la recherche utilisateur jusqu'au dossier stratégique remis à la ville.
 
 ## Le contexte et le mandat
 
-Yverdon-les-Bains est régulièrement noyée sous un brouillard qui pèse sur le moral… et sur l'image de la ville. Notre mandante souhaitait inverser cette perception et faire (re)découvrir le patrimoine yverdonnois aux **familles** de la région. Plutôt qu'une brochure ou un site de plus, nous avons proposé **AppY** : une application mobile qui transforme la ville en terrain de jeu conté, et qui récompense les familles chez les **commerçants locaux** à la fin de chaque parcours — un cercle vertueux entre découverte culturelle et économie de proximité.
+Yverdon-les-Bains est régulièrement noyée sous un brouillard qui pèse sur le moral… et sur l'image de la ville. Notre mandante souhaitait inverser cette perception et faire (re)découvrir le patrimoine yverdonnois aux **familles** de la région. Plutôt qu'une brochure ou un site de plus, nous avons proposé **AppY** : une application mobile qui transforme la ville en terrain de jeu conté, et qui récompense les familles chez les **commerçants locaux** à la fin de chaque parcours : un cercle vertueux entre découverte culturelle et économie de proximité.
 
 Le cadre était exigeant : neuf semaines, treize personnes aux compétences variées (UX, contenu, graphisme, marketing, technique) et une seule livraison finale attendue par une cliente réelle. Autant dire qu'au-delà du produit, l'enjeu était **organisationnel**.
 
@@ -48,10 +48,10 @@ Le cadre était exigeant : neuf semaines, treize personnes aux compétences vari
 
 J'étais **chef de projet**. Concrètement, j'ai assuré la **coordination et la gestion** de l'équipe de 13 :
 
-- **cadence agile** — animation des _dailies_, découpage en sprints, rédaction et suivi des PV, gestion du backlog et des priorités ;
-- **coordination inter-équipes** — faire converger des pôles très différents (recherche & UX, storytelling & contenu, branding, marketing, maquette) vers un livrable unique et cohérent ;
-- **lien avec la mandante** — points d'avancement, arbitrages et validation des orientations ;
-- **appui opérationnel** — au-delà de la gestion, j'ai **prêté main-forte sur tous les postes** selon les besoins du moment, de la conception à la communication.
+- **cadence agile** : animation des _dailies_, découpage en sprints, rédaction et suivi des PV, gestion du backlog et des priorités ;
+- **coordination inter-équipes** : faire converger des pôles très différents (recherche & UX, storytelling & contenu, branding, marketing, maquette) vers un livrable unique et cohérent ;
+- **lien avec la mandante** : points d'avancement, arbitrages et validation des orientations ;
+- **appui opérationnel** : au-delà de la gestion, j'ai **prêté main-forte sur tous les postes** selon les besoins du moment, de la conception à la communication.
 
 C'est un rôle de chef d'orchestre autant que de couteau suisse : garder le cap produit tout en gardant l'équipe alignée et la cliente rassurée.
 
@@ -59,18 +59,18 @@ C'est un rôle de chef d'orchestre autant que de couteau suisse : garder le cap 
 
 La difficulté n'était pas seulement de « faire une app ». Il fallait :
 
-- **capter des enfants** sans les river à un écran — l'app devait enrichir la balade, pas la remplacer ;
+- **capter des enfants** sans les river à un écran (l'app devait enrichir la balade, pas la remplacer) ;
 - **embarquer les parents**, décideurs et accompagnants, avec des informations pratiques utiles ;
 - **soutenir les commerces** locaux via un mécanisme de récompense soutenable ;
-- et surtout **donner envie de revenir** — un parcours qu'on ne fait qu'une fois n'a pas d'avenir.
+- et surtout **donner envie de revenir** : un parcours qu'on ne fait qu'une fois n'a pas d'avenir.
 
 ## Analyse des opportunités
 
-Avant de dessiner quoi que ce soit, nous avons investi dans la **recherche** : comprendre le marché, les usages et les attentes des deux publics — familles (B2C) et commerçants (B2B).
+Avant de dessiner quoi que ce soit, nous avons investi dans la **recherche** : comprendre le marché, les usages et les attentes des deux publics : familles (B2C) et commerçants (B2B).
 
 ### Benchmark
 
-Nous avons étudié les solutions existantes de balades et de jeux de piste urbains — **Foxtrail, Graaly, Totemi, « Je trottine dans ma ville »** ou encore « Les promenades de Floriane » — en nous concentrant sur l'**expérience utilisateur** et les **fonctionnalités** : cartographie, dimension ludique, gamification, types d'interactions. Ce panorama a mis en évidence les forces et les faiblesses de chacun et nourri nos propres choix de conception.
+Nous avons étudié les solutions existantes de balades et de jeux de piste urbains (**Foxtrail, Graaly, Totemi, « Je trottine dans ma ville »** ou encore « Les promenades de Floriane »), en nous concentrant sur l'**expérience utilisateur** et les **fonctionnalités** : cartographie, dimension ludique, gamification, types d'interactions. Ce panorama a mis en évidence les forces et les faiblesses de chacun et nourri nos propres choix de conception.
 
 ### Étude de marché B2C
 
@@ -79,52 +79,52 @@ Un **questionnaire quantitatif** et des **entretiens qualitatifs** ont été men
 - un intérêt marqué pour une app de **découverte d'activités familiales**, à condition qu'elle reste **simple** (le scan de QR code a été plébiscité) ;
 - une ouverture aux nouvelles technologies **tant qu'elles enrichissent** l'expérience familiale sans s'y substituer ;
 - la **gamification** perçue comme un moteur de participation, avec des récompenses qui renforcent le caractère familial et communautaire ;
-- un potentiel autour du **partage d'expérience** en communauté — mais en respectant la volonté de certains de limiter leur engagement social.
+- un potentiel autour du **partage d'expérience** en communauté, mais en respectant la volonté de certains de limiter leur engagement social.
 
 ### Étude de marché B2B
 
-Pour valider le volet commerçants, nous avons rencontré **une trentaine de commerçants**. L'échange le plus abouti (avec l'enseigne Ateapic) a confirmé un réel intérêt à soutenir le lancement pour gagner en visibilité — tout en soulevant une vraie question de modèle : **qui finance les bons de réduction sur le long terme** ? Un point que le dossier remonte explicitement à la ville.
+Pour valider le volet commerçants, nous avons rencontré **une trentaine de commerçants**. L'échange le plus abouti (avec l'enseigne Ateapic) a confirmé un réel intérêt à soutenir le lancement pour gagner en visibilité, tout en soulevant une vraie question de modèle : **qui finance les bons de réduction sur le long terme** ? C'est un point que le dossier remonte explicitement à la ville.
 
 ## Le concept : la ville comme terrain de jeu
 
-Le produit repose sur un **storytelling** simple et incarné. **Brumus**, un sorcier bienveillant mais maladroit, tente d'aider les habitants d'Yverdon ; ses sorts ratés provoquent des catastrophes cocasses. La **professeure Violette la Castorette**, magicienne respectée, appelle alors les familles à la rescousse pour réparer ses bêtises. Ce sont les **personnages, autant que les lieux**, qui donnent envie d'aller au poste suivant — et surtout de **revenir** pour retrouver ces héros. La narration suit la **courbe du suspense**, un principe pédagogique adapté aux enfants.
+Le produit repose sur un **storytelling** simple et incarné. **Brumus**, un sorcier bienveillant mais maladroit, tente d'aider les habitants d'Yverdon ; ses sorts ratés provoquent des catastrophes cocasses. La **professeure Violette la Castorette**, magicienne respectée, appelle alors les familles à la rescousse pour réparer ses bêtises. Ce sont les **personnages, autant que les lieux**, qui donnent envie d'aller au poste suivant, et surtout de **revenir** pour retrouver ces héros. La narration suit la **courbe du suspense**, un principe pédagogique adapté aux enfants.
 
-Le mécanisme de jeu est volontairement épuré : à chaque poste, un simple **scan de QR code** débloque un défi porté par un **dialogue audio** — observation de la faune, énigme, rébus, mini-jeu. Au bout du parcours, les familles récoltent des **bons à faire valoir chez les commerçants locaux**.
+Le mécanisme de jeu est volontairement épuré : à chaque poste, un simple **scan de QR code** débloque un défi porté par un **dialogue audio** : observation de la faune, énigme, rébus, mini-jeu. Au bout du parcours, les familles récoltent des **bons à faire valoir chez les commerçants locaux**.
 
 ## Deux parcours contés de bout en bout
 
-Deux parcours complets ont été écrits, scénarisés et mis en scène — l'un urbain, l'autre nature.
+Deux parcours complets ont été écrits, scénarisés et mis en scène : l'un urbain, l'autre nature.
 
-### « La Pierre de Joie » — le parcours urbain
+### « La Pierre de Joie », le parcours urbain
 
-**8–12 ans · ~2,5 km · ~1h15 · de la Place d'Armes au Château.** Violette demande aux familles d'aider **Piou-piou** à retrouver la _Pierre de Joie_ qu'il a égarée. Brumus, qui l'a récupérée, croit bien faire en voulant **augmenter son pouvoir**… mais l'affaiblit : plus le parcours avance, plus l'atmosphère devient morose — jusqu'à ce que Violette inverse le sort. Sept postes rythment l'aventure :
+**8–12 ans · ~2,5 km · ~1h15 · de la Place d'Armes au Château.** Violette demande aux familles d'aider **Piou-piou** à retrouver la _Pierre de Joie_ qu'il a égarée. Brumus, qui l'a récupérée, croit bien faire en voulant **augmenter son pouvoir**… mais l'affaiblit : plus le parcours avance, plus l'atmosphère devient morose, jusqu'à ce que Violette inverse le sort. Sept postes rythment l'aventure :
 
-1. **Place d'Armes** — quizz audio : reconnaître le cri de l'aigle parmi quatre propositions.
-2. **Kiosque à musique** — trouver un symbole qui oriente la carte de géomancie vers la Maison d'Ailleurs.
-3. **Maison d'Ailleurs** — rencontre avec **Picatso** : une activité de coloriage pour lui rendre l'inspiration.
-4. **Parc du Castrum** — un indice caché dans un livre en bois lance l'épreuve.
-5. **Place de jeux des Isles** — un _memory_ dans l'application.
-6. **Place de jeux Roger-de-Guimps** — un puzzle, indice dissimulé sous le toboggan.
-7. **Château d'Yverdon-les-Bains** — indiquer la bonne sortie à Brumus pour le libérer et inverser le sort.
+1. **Place d'Armes** : quizz audio, reconnaître le cri de l'aigle parmi quatre propositions.
+2. **Kiosque à musique** : trouver un symbole qui oriente la carte de géomancie vers la Maison d'Ailleurs.
+3. **Maison d'Ailleurs** : rencontre avec **Picatso**, une activité de coloriage pour lui rendre l'inspiration.
+4. **Parc du Castrum** : un indice caché dans un livre en bois lance l'épreuve.
+5. **Place de jeux des Isles** : un _memory_ dans l'application.
+6. **Place de jeux Roger-de-Guimps** : un puzzle, indice dissimulé sous le toboggan.
+7. **Château d'Yverdon-les-Bains** : indiquer la bonne sortie à Brumus pour le libérer et inverser le sort.
 
 C'est ce parcours qui a été porté jusqu'à une **maquette interactive haute-fidélité** (visible dans la démo ci-dessus).
 
-### « Le marais oublié » — le parcours nature
+### « Le marais oublié », le parcours nature
 
 **6–10 ans · ~4 km · ~2h · autour des menhirs de Clendy.** Ici, Violette sollicite les enfants pour **lever le sortilège d'oubli** que Brumus a accidentellement jeté sur les habitants. Le parcours fait découvrir les rives du lac et la biodiversité locale à travers huit stations d'observation :
 
-1. **Les menhirs** — Violette présente le site et son histoire.
-2. **L'observatoire de la petite plage** — retrouver les trois zones de l'écosystème du marais.
-3. **Le saule argenté** — aider **Splash le canard** en comptant les oiseaux visibles.
-4. **Sauvetage des Iris** — à la découverte du bateau de sauvetage.
-5. **Voyage immobile** — deviner quelle ville regarde la statue de Denis Perret-Gentil.
-6. **La jetée** — convaincre **Igor le castor** en répondant à des questions sur les castors.
-7. **Place de jeu** — identifier quatre traces d'animaux.
-8. **Le canal** — **Juliette la mouette** et un rébus final qui permet à Violette de déjouer le mauvais sort.
+1. **Les menhirs** : Violette présente le site et son histoire.
+2. **L'observatoire de la petite plage** : retrouver les trois zones de l'écosystème du marais.
+3. **Le saule argenté** : aider **Splash le canard** en comptant les oiseaux visibles.
+4. **Sauvetage des Iris** : à la découverte du bateau de sauvetage.
+5. **Voyage immobile** : deviner quelle ville regarde la statue de Denis Perret-Gentil.
+6. **La jetée** : convaincre **Igor le castor** en répondant à des questions sur les castors.
+7. **Place de jeu** : identifier quatre traces d'animaux.
+8. **Le canal** : **Juliette la mouette** et un rébus final qui permet à Violette de déjouer le mauvais sort.
 
 ### Une galerie de personnages
 
-L'univers s'appuie sur une petite troupe récurrente — **Violette la Castorette**, **Brumus** le sorcier, **Piou-piou**, **Picatso** le chat-artiste, **Splash** le canard, **Juliette** la mouette et **Igor** le castor — pensée pour être mémorable et extensible bien au-delà de l'application.
+L'univers s'appuie sur une petite troupe récurrente (**Violette la Castorette**, **Brumus** le sorcier, **Piou-piou**, **Picatso** le chat-artiste, **Splash** le canard, **Juliette** la mouette et **Igor** le castor), pensée pour être mémorable et extensible bien au-delà de l'application.
 
 ## La démarche UX
 
@@ -138,16 +138,16 @@ L'application est le fruit d'une chaîne méthodique, chaque étape nourrissant 
 6. **maquettes papier**, puis versions **_middle-fidelity_** ;
 7. **maquette interactive haute-fidélité** sur Figma.
 
-La conception a été confrontée au réel : **un retour d'expert et deux tests utilisateurs** menés avec des parents de la région d'Yverdon. Ces sessions ont directement fait évoluer le produit — **narration intégrée au cœur des fonctionnalités**, priorité aux **filtres** (âge recommandé, durée estimée, accessibilité poussette), **onglet dédié aux commerçants partenaires**, **tutoriel** d'accueil, mise en évidence sur la carte des **commodités utiles aux parents** (toilettes, arrêts de bus, places de jeux) et gestion des cas **hors connexion**. Trois piliers ont émergé de cette phase : les **parcours**, les **commerçants** et la **narration**.
+La conception a été confrontée au réel : **un retour d'expert et deux tests utilisateurs** menés avec des parents de la région d'Yverdon. Ces sessions ont directement fait évoluer le produit : **narration intégrée au cœur des fonctionnalités**, priorité aux **filtres** (âge recommandé, durée estimée, accessibilité poussette), **onglet dédié aux commerçants partenaires**, **tutoriel** d'accueil, mise en évidence sur la carte des **commodités utiles aux parents** (toilettes, arrêts de bus, places de jeux) et gestion des cas **hors connexion**. Trois piliers ont émergé de cette phase : les **parcours**, les **commerçants** et la **narration**.
 
 ## L'architecture de l'application
 
 L'app s'organise autour de **quatre onglets**, directement issus de la recherche :
 
-- **Parcours** — choisir son aventure en liste ou sur une **carte** interactive, avec filtres (popularité, proximité, longueur, durée, nombre d'activités…) ;
-- **Histoires** — des épisodes narratifs mettant en scène Violette et Brumus, qui donnent envie de découvrir d'autres parcours (et inversement) ;
-- **Bons** — les récompenses à dépenser chez les commerçants partenaires, qui mettent en lumière le tissu commercial yverdonnois ;
-- **Profil** — trophées liés à chaque parcours, statistiques et personnalisation, pour entretenir la motivation.
+- **Parcours** : choisir son aventure en liste ou sur une **carte** interactive, avec filtres (popularité, proximité, longueur, durée, nombre d'activités…) ;
+- **Histoires** : des épisodes narratifs mettant en scène Violette et Brumus, qui donnent envie de découvrir d'autres parcours (et inversement) ;
+- **Bons** : les récompenses à dépenser chez les commerçants partenaires, qui mettent en lumière le tissu commercial yverdonnois ;
+- **Profil** : trophées liés à chaque parcours, statistiques et personnalisation, pour entretenir la motivation.
 
 Plusieurs partis pris d'expérience renforcent l'ensemble : des **interactions non-visuelles** (le texte est joué en **audio**, et une **vibration + sonnerie** signale l'arrivée près d'un poste pour éviter de garder le nez sur l'écran), un **compteur d'activité** affichant le nombre de familles sur le parcours en cours, et une **progression ludifiée** (XP, succès, parrainage).
 
@@ -155,8 +155,8 @@ Plusieurs partis pris d'expérience renforcent l'ensemble : des **interactions n
 
 Deux décisions structurantes, assumées et documentées :
 
-- **QR code plutôt que NFC ou Bluetooth** — universel, sans matériel spécifique ni surconsommation d'énergie, compatible avec tous les smartphones : l'accessibilité maximale primait.
-- **Mode hors-ligne** — les parcours traversent des zones à faible couverture réseau ; les contenus se **préchargent en Wi-Fi** puis fonctionnent sans connexion.
+- **QR code plutôt que NFC ou Bluetooth** : universel, sans matériel spécifique ni surconsommation d'énergie, compatible avec tous les smartphones. L'accessibilité maximale primait.
+- **Mode hors-ligne** : les parcours traversent des zones à faible couverture réseau ; les contenus se **préchargent en Wi-Fi** puis fonctionnent sans connexion.
 
 L'équipe a par ailleurs fait le choix stratégique de **concentrer l'effort sur la conception** (recherche, UX, prototype interactif, branding, marketing) **plutôt que sur le développement**, afin de remettre à la ville un dossier directement transmissible à une agence pour la réalisation.
 
@@ -168,11 +168,11 @@ En parallèle de l'app, l'équipe a bâti une **identité complète** : une **ch
 
 Le dossier inclut une **stratégie de communication sur un an**, pensée pour installer AppY et sa ville dans l'esprit des familles.
 
-- **Cibles** — les familles d'Yverdon, de **Lausanne** et du **Nord Vaudois**, classe moyenne à aisée, amatrices de nature et d'activités extérieures.
-- **Positionnement** — un univers **familial, sympathique et éducatif**, articulé autour de quatre axes : des personnages **bienveillants et drôles** créant une connexion émotionnelle, des **informations pratiques** pour les parents, une dimension **éducative** (nature, respect des animaux, écologie) et la **proximité** de l'offre.
-- **Canaux** — présence continue sur **Instagram et Facebook** (campagne intensive de mars à août), **TikTok** (janvier à juillet), **stands** lors d'événements vaudois, passages **TV/radio** famille, **mini-BD** dans les magazines pour enfants et partenariat avec le site **VaudFamille**.
-- **Action phare** — un **flocage de bus à Lausanne pendant 13 semaines** avant l'été, point culminant de la campagne, épaulé par de l'affichage classique et des flyers.
-- **Budget** — un plan chiffré de **138 435 CHF/an** (flocage de bus, campagnes réseaux sociaux ~32 400 CHF, produits dérivés ~13 406 CHF, TV/radio ~9 600 CHF, affichage, flyers, partenariats…), accompagné d'un **calendrier éditorial** prêt à l'emploi.
+- **Cibles** : les familles d'Yverdon, de **Lausanne** et du **Nord Vaudois**, classe moyenne à aisée, amatrices de nature et d'activités extérieures.
+- **Positionnement** : un univers **familial, sympathique et éducatif**, articulé autour de quatre axes : des personnages **bienveillants et drôles** créant une connexion émotionnelle, des **informations pratiques** pour les parents, une dimension **éducative** (nature, respect des animaux, écologie) et la **proximité** de l'offre.
+- **Canaux** : présence continue sur **Instagram et Facebook** (campagne intensive de mars à août), **TikTok** (janvier à juillet), **stands** lors d'événements vaudois, passages **TV/radio** famille, **mini-BD** dans les magazines pour enfants et partenariat avec le site **VaudFamille**.
+- **Action phare** : un **flocage de bus à Lausanne pendant 13 semaines** avant l'été, point culminant de la campagne, épaulé par de l'affichage classique et des flyers.
+- **Budget** : un plan chiffré de **138 435 CHF/an** (flocage de bus, campagnes réseaux sociaux ~32 400 CHF, produits dérivés ~13 406 CHF, TV/radio ~9 600 CHF, affichage, flyers, partenariats…), accompagné d'un **calendrier éditorial** prêt à l'emploi.
 
 ## Le livrable remis à la ville
 
@@ -186,11 +186,11 @@ Au terme du projet, la ville d'Yverdon-les-Bains a reçu un **dossier clé en ma
 
 ## Perspectives
 
-Pensé comme une franchise plus que comme une simple app, l'univers AppY est **hautement évolutif** : histoires parallèles, livres, bandes dessinées et livres audio, contenu didactique pour l'apprentissage de la lecture, produits dérivés (peluches, papeterie…), voire un dessin animé. À terme, l'ambition est de faire de Violette et Brumus des figures familières des familles de Suisse romande — et d'Yverdon-les-Bains un véritable **rendez-vous familial**.
+Pensé comme une franchise plus que comme une simple app, l'univers AppY est **hautement évolutif** : histoires parallèles, livres, bandes dessinées et livres audio, contenu didactique pour l'apprentissage de la lecture, produits dérivés (peluches, papeterie…), voire un dessin animé. À terme, l'ambition est de faire de Violette et Brumus des figures familières des familles de Suisse romande, et d'Yverdon-les-Bains un véritable **rendez-vous familial**.
 
 ## Ce que j'en retire
 
-Coordonner **13 personnes** sur un projet aussi transverse — développement, UX, contenu, communication, marketing — m'a appris à **faire converger des métiers très différents** vers un livrable unique et cohérent. J'en retiens surtout la valeur des **arbitrages** (concentrer l'effort sur la conception plutôt que le code, choisir le QR contre le NFC), l'importance d'une **cadence agile** tenue de bout en bout, et la nécessité de garder en permanence deux caps alignés : la **satisfaction de la mandante** et la **cohérence produit**, du premier atelier jusqu'au dossier final.
+Coordonner **13 personnes** sur un projet aussi transverse (développement, UX, contenu, communication, marketing) m'a appris à **faire converger des métiers très différents** vers un livrable unique et cohérent. J'en retiens surtout la valeur des **arbitrages** (concentrer l'effort sur la conception plutôt que le code, choisir le QR contre le NFC), l'importance d'une **cadence agile** tenue de bout en bout, et la nécessité de garder en permanence deux caps alignés : la **satisfaction de la mandante** et la **cohérence produit**, du premier atelier jusqu'au dossier final.
 
 ## Démo
 

--- a/src/content/project/chuv-blocs-operatoires.mdx
+++ b/src/content/project/chuv-blocs-operatoires.mdx
@@ -9,7 +9,7 @@ image: "../../assets/tb-chuv/maquette-app.avif"
 type: "general"
 category: "web"
 role: "UX research & conception UI (travail de bachelor)"
-client: "CHUV — Centre hospitalier universitaire vaudois"
+client: "CHUV (Centre hospitalier universitaire vaudois)"
 featured: 85
 skills:
   - "UX research"
@@ -21,7 +21,7 @@ skills:
 
 import ImageGallery from "../../components/ui/ImageGallery.astro";
 
-**« Optimisation des plans d'installation pour les équipements biomédicaux dans les blocs opératoires du CHUV »** — mon travail de bachelor (HEIG-VD, Ingénierie des médias, 2024), sur un sujet proposé par le CHUV et suivi par une répondante externe de l'institution.
+**« Optimisation des plans d'installation pour les équipements biomédicaux dans les blocs opératoires du CHUV »**, mon travail de bachelor (HEIG-VD, Ingénierie des médias, 2024), sur un sujet proposé par le CHUV et suivi par une répondante externe de l'institution.
 
 ## Le problème
 
@@ -45,9 +45,9 @@ J'ai conçu l'UX/UI complète d'une application mobile permettant au personnel d
 
 Le travail pose aussi les bases des étapes suivantes, avec leurs avantages et limites documentés :
 
-1. **Court terme** — application mobile de visualisation des plans (rapide, peu coûteuse, sans localisation dynamique).
-2. **Moyen terme** — suivi des équipements par **QR codes et caméras** (précision améliorée à coût faible).
-3. **Long terme** — localisation **en temps réel par UWB** (Ultra-Wideband), couplée à un retour visuel complet (haute précision, mais coût et intégration plus lourds).
+1. **Court terme** : application mobile de visualisation des plans (rapide, peu coûteuse, sans localisation dynamique).
+2. **Moyen terme** : suivi des équipements par **QR codes et caméras** (précision améliorée à coût faible).
+3. **Long terme** : localisation **en temps réel par UWB** (Ultra-Wideband), couplée à un retour visuel complet (haute précision, mais coût et intégration plus lourds).
 
 ## Galerie
 

--- a/src/content/project/corps-et-ame.mdx
+++ b/src/content/project/corps-et-ame.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Assistant production & image sur Corps & Âme — documentaire"
+title: "Assistant production & image sur Corps & Âme (documentaire)"
 pubDate: 2025-04-27
 intro: "Sur ce documentaire de Lan Ponti consacré à Lalie, jeune danseuse, j'ai accompagné la production, l'image et la musique. Le film interroge la frontière entre passion et santé mentale."
 seoDescription: "Corps & Âme, un documentaire de Lan Ponti. Assistant de production, image et musique sur ce film explorant la passion et la santé mentale d'une jeune danseuse."

--- a/src/content/project/frencha-clip.mdx
+++ b/src/content/project/frencha-clip.mdx
@@ -1,15 +1,16 @@
 ---
-title: "Photographe de plateau — Cactus Heart, clip de Frencha"
+title: "Assistant caméra & photographe de plateau sur Cactus Heart (clip de Frencha)"
 pubDate: 2024-02-08
-intro: "Photographie de plateau et assistanat sur le tournage de Cactus Heart : documenter les coulisses et fournir à l'artiste des images prêtes pour sa promotion."
-seoDescription: "Découvrez les coulisses du clip 'Cactus Heart' de Frencha. Mon travail en tant qu'assistant et photographe de plateau pour immortaliser ce projet musical."
+intro: "Assistant caméra sur Cactus Heart, j'ai aussi documenté les coulisses comme photographe de plateau et fourni à l'artiste des images prêtes pour sa promotion."
+seoDescription: "Coulisses du clip « Cactus Heart » de Frencha : mon travail d'assistant caméra et de photographe de plateau."
 tag: clip musical
 author: samuel
 image: "../../assets/cactus-heart.avif"
 type: video
 videoUrl: https://www.youtube.com/watch?v=CRaab1EEGuw
-category: "photo"
-role: "Photographe de plateau & assistant"
+category: "video"
+secondaryCategories: ["photo"]
+role: "Assistant caméra & photographe de plateau"
 client: "Frencha"
 featured: 40
 ---
@@ -20,12 +21,12 @@ Cactus Heart est une œuvre visuelle marquante de l'artiste Frencha. Participer 
 
 ## Mon rôle
 
-En tant que **Photographe de Plateau**, ma mission était double :
+Mon poste principal était celui d'**assistant caméra** : préparer et servir la caméra, gérer les optiques et veiller à ce que chaque plan soit techniquement prêt, en soutien à la fluidité des opérations techniques et logistiques du tournage.
 
-1.  **Documenter les coulisses** : Capturer les moments de concentration, les échanges techniques et l'énergie de l'équipe.
-2.  **Créer du contenu promotionnel** : Fournir des images de haute qualité pour la communication de l'artiste et du clip.
+Comme **photographe de plateau**, ma mission était double :
 
-J'ai également apporté mon soutien en tant qu'**Assistant**, aidant à la fluidité des opérations techniques et logistiques.
+1. **Documenter les coulisses** : capturer les moments de concentration, les échanges techniques et l'énergie de l'équipe.
+2. **Créer du contenu promotionnel** : fournir des images de haute qualité pour la communication de l'artiste et du clip.
 
 ---
 

--- a/src/content/project/gym-tracker.mdx
+++ b/src/content/project/gym-tracker.mdx
@@ -1,8 +1,8 @@
 ---
-title: "GymTracker — application de suivi de musculation"
+title: "GymTracker, une application de suivi de musculation"
 pubDate: 2026-05-04
-intro: "Une application web de suivi de musculation, mobile-first et pensée comme un vrai produit : séances et modèles, détection automatique des records, statistiques de progression, suivi santé et OAuth social — le tout porté par une exigence d'ingénierie élevée (PHPStan niveau 9, 750+ tests)."
-seoDescription: "App de suivi de musculation (Laravel 12, Vue 3, Inertia, PWA) : séances, records, stats et suivi santé — 750+ tests, PHPStan niveau 9."
+intro: "Une application web de suivi de musculation, mobile-first et pensée comme un vrai produit : séances et modèles, détection automatique des records, statistiques de progression, suivi santé et OAuth social, le tout porté par une exigence d'ingénierie élevée (PHPStan niveau 9, 750+ tests)."
+seoDescription: "App de suivi de musculation (Laravel 12, Vue 3, Inertia, PWA) : séances, records, stats et suivi santé : 750+ tests, PHPStan niveau 9."
 tag: "application web"
 author: "samuel"
 image: "../../assets/gym-tracker/cover.avif"
@@ -36,10 +36,10 @@ import ImageGallery from "../../components/ui/ImageGallery.astro";
 
 Le cœur du produit, c'est la séance :
 
-- **Séances & modèles** — démarrer vite depuis ses routines favorites, ou créer une séance libre ;
-- **Records personnels (PR)** — détection **automatique** des nouveaux records (poids, 1RM estimé, volume) ;
-- **Streak counter** — le suivi des jours consécutifs pour entretenir la motivation ;
-- **Calculateurs** — estimation du 1RM et aide au chargement des plaques.
+- **Séances & modèles** : démarrer vite depuis ses routines favorites, ou créer une séance libre ;
+- **Records personnels (PR)** : détection **automatique** des nouveaux records (poids, 1RM estimé, volume) ;
+- **Streak counter** : le suivi des jours consécutifs pour entretenir la motivation ;
+- **Calculateurs** : estimation du 1RM et aide au chargement des plaques.
 
 ## Statistiques & santé
 
@@ -47,17 +47,17 @@ GymTracker va au-delà du carnet d'entraînement pour suivre la progression dans
 
 - **graphiques de progression** interactifs (volume, charges maximales) ;
 - **suivi d'habitudes** (créatine, méditation, sommeil…) ;
-- **constantes & composition corporelle** — tension, fréquence cardiaque, estimation du taux de masse grasse (méthode US Navy) ;
+- **constantes & composition corporelle** : tension, fréquence cardiaque, estimation du taux de masse grasse (méthode US Navy) ;
 - **mesures corporelles** pour visualiser l'évolution physique.
 
 ## Sécurité & authentification
 
 - **OAuth social** (Google, GitHub, Apple) pour une connexion sans friction ;
-- **sécurité renforcée** — throttling des API, **CSP stricte** et protection par nonce.
+- **sécurité renforcée** : throttling des API, **CSP stricte** et protection par nonce.
 
 ## Une vraie exigence d'ingénierie
 
-Ce qui distingue GymTracker, c'est le niveau de qualité de code visé — celui d'un projet professionnel :
+Ce qui distingue GymTracker, c'est le niveau de qualité de code visé, celui d'un projet professionnel :
 
 - **PHP 8.5 en typage strict**, analyse statique **PHPStan niveau 9** ;
 - **PHP Insights** : score de 100 % en architecture et complexité ;
@@ -76,7 +76,7 @@ Ce qui distingue GymTracker, c'est le niveau de qualité de code visé — celui
 
 ## Ce que j'en retire
 
-GymTracker est le projet où je pousse le plus loin l'**exigence full-stack** : conjuguer une interface mobile agréable et un back-end tenu par des tests et une analyse statique sans compromis. C'est ma démonstration qu'un projet personnel peut viser — et tenir — des standards de production.
+GymTracker est le projet où je pousse le plus loin l'**exigence full-stack** : conjuguer une interface mobile agréable et un back-end tenu par des tests et une analyse statique sans compromis. C'est ma démonstration qu'un projet personnel peut viser, et tenir, des standards de production.
 
 ## Galerie
 

--- a/src/content/project/izia-fete-musique.mdx
+++ b/src/content/project/izia-fete-musique.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reportage photo — Les Quesaco à la Fête de la Musique 2024"
+title: "Reportage photo : Les Quesaco à la Fête de la Musique 2024"
 pubDate: 2024-06-21
 intro: "Reportage photo au cœur du concert des Quesaco à Morges : capter l'énergie de la scène, les jeux de lumière et la complicité entre les artistes et leur public."
 seoDescription: "Reportage photo du concert des Quesaco à la Fête de la Musique 2024 à Morges. Capturer l'énergie et l'émotion de la scène."

--- a/src/content/project/izia-proudRebel.mdx
+++ b/src/content/project/izia-proudRebel.mdx
@@ -1,15 +1,16 @@
 ---
-title: "Photographe de plateau — Proud Rebel, clip d'Izia Jeen"
+title: "Assistant caméra & photographe de plateau sur Proud Rebel (clip d'Izia Jeen)"
 pubDate: 2024-09-27
-intro: "Photographie de plateau et assistanat sur Proud Rebel : saisir l'énergie du tournage et livrer les images qui portent aujourd'hui la promotion du titre."
-seoDescription: "Découvrez les coulisses du clip 'Proud Rebel' de Izia Jeen. Mon travail en tant qu'assistant et photographe de plateau."
+intro: "Assistant caméra sur Proud Rebel, j'ai aussi saisi l'énergie du tournage comme photographe de plateau et livré les images qui portent la promotion du titre."
+seoDescription: "Coulisses du clip « Proud Rebel » d'Izia Jeen : mon travail d'assistant caméra et de photographe de plateau."
 tag: clip musical
 author: samuel
 image: "../../assets/proud-rebel.avif"
 type: video
 videoUrl: https://www.youtube.com/watch?v=FKZfxkPd4wk
-category: "photo"
-role: "Photographe de plateau & assistant"
+category: "video"
+secondaryCategories: ["photo"]
+role: "Assistant caméra & photographe de plateau"
 client: "Izia Jeen"
 featured: 68
 ---
@@ -19,13 +20,13 @@ import { YouTube } from "astro-embed";
 
 Proud Rebel marque un véritable tournant dans la carrière artistique d'Izia Jeen. Ce clip, à la fois vibrant, audacieux et empreint d'une énergie libératrice, nécessitait une approche visuelle tout aussi percutante pour documenter chaque étape de sa création. L'enjeu était de taille : il ne s'agissait pas seulement de filmer, mais de figer l'essence même d'une rébellion assumée.
 
+## Au plus près de la caméra
+
+Mon poste principal sur ce tournage était celui d'**assistant caméra** : préparer et servir la caméra, gérer les optiques et veiller à ce que chaque plan soit techniquement prêt. Sur un projet aussi dynamique que _Proud Rebel_, la réactivité est primordiale. Qu'il s'agisse d'ajuster une installation lumière de dernière minute, de gérer le matériel ou de faciliter la communication entre les pôles créatifs, cette place au plus près de l'image m'a permis d'appréhender le projet dans sa globalité et de garantir la fluidité du tournage, pour que la vision artistique s'exprime sans entrave technique.
+
 ## Au cœur de l'action et de l'émotion
 
-En tant que **Photographe de Plateau**, ma mission principale a été de m'immerger totalement dans l'ambiance du tournage afin de saisir l'intensité brute des performances. L’enjeu était de rester discret tout en captant la synergie bouillonnante de l'équipe technique, l'osmose entre la réalisatrice et l'artiste, ainsi que les moments de concentration intenses avant chaque prise. Ces clichés, pris sur le vif, servent aujourd'hui de pilier pour la promotion du titre sur les réseaux sociaux et les différentes plateformes de streaming, offrant au public une fenêtre privilégiée sur la genèse de l'œuvre.
-
-## La polyvalence sur le plateau
-
-En parallèle de la photographie, j'ai eu l'opportunité d'assister directement l'équipe de production. Sur un tournage aussi dynamique que celui de _Proud Rebel_, la réactivité est primordiale. Qu'il s'agisse d'ajuster une installation lumière de dernière minute, de gérer la logistique du matériel ou de faciliter la communication entre les différents pôles créatifs, cette casquette d'assistant m'a permis d'appréhender le projet dans sa globalité. Cette double compétence est un atout majeur pour garantir la fluidité d'un tournage et assurer que la vision artistique puisse s'exprimer sans entrave technique.
+Comme **photographe de plateau**, je me suis immergé dans l'ambiance du tournage afin de saisir l'intensité brute des performances. L'enjeu était de rester discret tout en captant la synergie bouillonnante de l'équipe technique, l'osmose entre la réalisatrice et l'artiste, ainsi que les moments de concentration intenses avant chaque prise. Ces clichés, pris sur le vif, servent aujourd'hui de pilier pour la promotion du titre sur les réseaux sociaux et les différentes plateformes de streaming, offrant au public une fenêtre privilégiée sur la genèse de l'œuvre.
 
 Ce projet reste pour moi une aventure créative très stimulante, mêlant défis techniques et exigences esthétiques.
 

--- a/src/content/project/jimmy-cpdv.mdx
+++ b/src/content/project/jimmy-cpdv.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Réalisation d'un clip pour Jimmy Capdevila"
 pubDate: 2022-11-16
-intro: "De l'écriture du storyboard à la post-production, j'ai réalisé ce clip de bout en bout pour Jimmy Capdevila — une collaboration artistique au plus près de sa sensibilité musicale."
+intro: "De l'écriture du storyboard à la post-production, j'ai réalisé ce clip de bout en bout pour Jimmy Capdevila, une collaboration artistique au plus près de sa sensibilité musicale."
 seoDescription: "Coulisses de la réalisation du clip musical pour Jimmy Capdevila. Storyboard, tournage, post-production : un processus créatif complet."
 tag: clip musical
 author: samuel

--- a/src/content/project/lamia-clip.mdx
+++ b/src/content/project/lamia-clip.mdx
@@ -1,15 +1,16 @@
 ---
-title: "Photographe de plateau — 478, clip de Lamia"
+title: "Assistant caméra & photographe de plateau sur 478 (clip de Lamia)"
 pubDate: 2025-07-18
-intro: "Sur le tournage du clip 478, j'ai documenté la production en tant que photographe de plateau et appuyé l'équipe comme assistant, au service d'une atmosphère envoûtante."
-seoDescription: "Coulisses du clip '478' de Lamia. Mon rôle d'assistant et de photographe de plateau pour documenter ce projet musical unique."
+intro: "Sur le tournage du clip 478, j'étais assistant caméra ; j'ai aussi documenté la production comme photographe de plateau, au service d'une atmosphère envoûtante."
+seoDescription: "Coulisses du clip « 478 » de Lamia : mon travail d'assistant caméra et de photographe de plateau sur ce projet musical."
 tag: clip musical
 author: samuel
 image: "../../assets/lamia.avif"
 type: video
 videoUrl: https://www.youtube.com/watch?v=BHNkP9E9Urs
-category: "photo"
-role: "Photographe de plateau & assistant"
+category: "video"
+secondaryCategories: ["photo"]
+role: "Assistant caméra & photographe de plateau"
 client: "Lamia"
 featured: 45
 ---
@@ -17,13 +18,13 @@ featured: 45
 import ImageGallery from "../../components/ui/ImageGallery.astro";
 import { YouTube } from "astro-embed";
 
-Le clip **478** de Lamia est une plongée dans un univers visuel soigné et poétique. Ce projet m'a permis de combiner mes deux casquettes — photographe de plateau et assistant de production — au service d'une vision artistique singulière.
+Le clip **478** de Lamia est une plongée dans un univers visuel soigné et poétique. Ce projet m'a permis de conjuguer mes deux casquettes, assistant caméra et photographe de plateau, au service d'une vision artistique singulière.
 
 ## Mon rôle sur le plateau
 
-En tant que **Photographe de Plateau**, j'ai documenté chaque étape de la production, des préparatifs minutieux aux prises de vues finales. L'enjeu principal était de capturer l'atmosphère envoûtante du clip tout en restant discret pour ne pas perturber le travail de l'équipe. Ces images permettent de prolonger l'expérience du clip en dévoilant l'envers du décor et servent de supports promotionnels pour la communication de l'artiste.
+Mon poste principal était celui d'**assistant caméra** : préparer et servir la caméra, gérer les optiques et veiller à ce que chaque plan soit techniquement prêt, pour laisser l'équipe image concentrée sur la mise en scène. De la gestion du matériel à la coordination logistique entre les différents pôles, cette place au plus près de la caméra m'a permis de contribuer activement à la fluidité du tournage.
 
-J'ai également apporté mon aide technique en tant qu'**Assistant**, veillant à ce que chaque plan puisse être réalisé dans les meilleures conditions. De la gestion du matériel d'éclairage à la coordination logistique entre les différentes équipes, cette polyvalence m'a permis de contribuer activement à la fluidité du tournage.
+En parallèle, j'ai documenté chaque étape de la production comme **photographe de plateau**, des préparatifs minutieux aux prises de vues finales. L'enjeu était de capturer l'atmosphère envoûtante du clip tout en restant discret pour ne pas perturber le travail de l'équipe. Ces images prolongent l'expérience du clip en dévoilant l'envers du décor et servent de supports promotionnels pour la communication de l'artiste.
 
 ## Une esthétique maîtrisée
 

--- a/src/content/project/larev.mdx
+++ b/src/content/project/larev.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Co-production & communication — Beaucoup de Bruit pour Rien"
+title: "Co-production & communication sur Beaucoup de Bruit pour Rien"
 pubDate: 2024-04-25
 intro: "Avec la troupe Les Insomniaques, j'ai co-produit et porté la communication de cette réinterprétation post-apocalyptique de Shakespeare, de l'affiche à la salle."
 seoDescription: "Production théâtrale 'Beaucoup de Bruit pour Rien' par la troupe Les Insomniaques. Une réinterprétation post-apocalyptique de Shakespeare."

--- a/src/content/project/lola-clip.mdx
+++ b/src/content/project/lola-clip.mdx
@@ -1,15 +1,16 @@
 ---
-title: "Photographe de plateau — Fly Away, clip de Lola"
+title: "Assistant caméra & photographe de plateau sur Fly Away (clip de Lola)"
 pubDate: 2024-01-30
-intro: "Photographie de plateau et assistanat sur Fly Away : traduire en images fixes l'univers onirique du titre, pour la promotion de l'artiste."
-seoDescription: "Coulisses du clip 'Fly Away' de Lola. Mon travail d'assistant et de photographe de plateau pour ce projet musical onirique."
+intro: "Assistant caméra sur Fly Away, j'ai aussi traduit en images fixes, comme photographe de plateau, l'univers onirique du titre pour la promotion de l'artiste."
+seoDescription: "Coulisses du clip « Fly Away » de Lola : mon travail d'assistant caméra et de photographe de plateau sur ce projet musical onirique."
 tag: clip musical
 author: samuel
 image: "../../assets/lola-clip/IMG_0879 (Grand).avif"
 type: video
 videoUrl: https://www.youtube.com/watch?v=I97Ghw2hvMw
-category: "photo"
-role: "Photographe de plateau & assistant"
+category: "video"
+secondaryCategories: ["photo"]
+role: "Assistant caméra & photographe de plateau"
 client: "Lola"
 featured: 42
 ---
@@ -17,15 +18,15 @@ featured: 42
 import ImageGallery from "../../components/ui/ImageGallery.astro";
 import { YouTube } from "astro-embed";
 
-Avec son univers musical si particulier, le titre _Fly Away_ de Lola a pour vocation première de nous inviter à l'évasion pure. Ce clip vidéo, doté d'une esthétique minutieusement soignée et d'une ambiance quasiment cinématographique, constituait pour moi un terrain d'expression idéal en matière de photographie de plateau. L'univers onirique du titre s'est traduit par des choix très forts en termes de lumière, de textures et de décors.
-
-## Saisir la poésie de l'instant
-
-Mon rôle lors de ce tournage fut avant tout d'agir comme témoin silencieux de la création. Il s'agissait de saisir la poésie des instants volés entre chaque prise de vue, de documenter non seulement l'artiste mais l'envers du décor. La lumière naturelle, combinée aux setups très organiques voulus par la production, m'a offert un cadre magnifique, permettant à mes clichés d'adopter des tons particulièrement chauds et nostalgiques. L'enjeu était de produire un matériel photographique parfaitement raccord avec l'ambiance du morceau pour les besoins promotionnels de Lola.
+Avec son univers musical si particulier, le titre _Fly Away_ de Lola a pour vocation première de nous inviter à l'évasion pure. Ce clip vidéo, doté d'une esthétique minutieusement soignée et d'une ambiance quasiment cinématographique, m'a offert un beau terrain de jeu, autant comme assistant caméra que comme photographe de plateau. L'univers onirique du titre s'est traduit par des choix très forts en termes de lumière, de textures et de décors.
 
 ## Un rouage de la production technique
 
-Au-delà de l'objectif de l'appareil photo, j'ai eu l'opportunité de travailler comme assistant de plateau. Un tournage aux ambitions oniriques nécessite souvent une très grande rigueur technique (effets pratiques, accessoires particuliers, gestion stricte de la lumière selon l'heure du jour). Mon action a consisté à soutenir l'équipe pour garantir que la vision du réalisateur puisse prendre vie sans le moindre accroc, permettant à tous les techniciens de rester concentrés sur leur pôle.
+Mon poste principal sur ce tournage était celui d'**assistant caméra**. Un tournage aux ambitions oniriques exige une grande rigueur technique (effets pratiques, accessoires particuliers, gestion stricte de la lumière selon l'heure du jour). Au plus près de la caméra, mon action a consisté à préparer et servir l'appareil, à gérer les optiques et à soutenir l'équipe pour garantir que la vision du réalisateur prenne vie sans le moindre accroc, en laissant chaque technicien concentré sur son pôle.
+
+## Saisir la poésie de l'instant
+
+En marge de la caméra, j'ai aussi agi comme **photographe de plateau**, témoin silencieux de la création. Il s'agissait de saisir la poésie des instants volés entre chaque prise de vue, de documenter non seulement l'artiste mais l'envers du décor. La lumière naturelle, combinée aux setups très organiques voulus par la production, m'a offert un cadre magnifique, permettant à mes clichés d'adopter des tons particulièrement chauds et nostalgiques. L'enjeu était de produire un matériel photographique parfaitement raccord avec l'ambiance du morceau pour les besoins promotionnels de Lola.
 
 ---
 

--- a/src/content/project/musees-pully.mdx
+++ b/src/content/project/musees-pully.mdx
@@ -1,15 +1,15 @@
 ---
-title: "Maquettes UX — Association des Amis des musées de Pully"
+title: "Maquettes UX pour l'Association des Amis des musées de Pully"
 pubDate: 2023-12-10
-intro: "Conception d'un site pour l'association des Amis des musées de Pully : horaires et carte des trois musées, concours « Révélations Artistiques de Demain », adhésion, dons et newsletter — maquettes haute-fidélité déclinées en mobile et desktop."
-seoDescription: "Étude de cas UX (HEIG-VD) : maquettes mobile et desktop du site des Amis des musées de Pully — musées, concours artistique, adhésion et dons."
+intro: "Conception d'un site pour l'association des Amis des musées de Pully : horaires et carte des trois musées, concours « Révélations Artistiques de Demain », adhésion, dons et newsletter : maquettes haute-fidélité déclinées en mobile et desktop."
+seoDescription: "Étude de cas UX (HEIG-VD) : maquettes mobile et desktop du site des Amis des musées de Pully : musées, concours artistique, adhésion et dons."
 tag: "ux design"
 author: "samuel"
 image: "../../assets/musees-pully/accueil-mobile.avif"
 type: "general"
 category: "web"
 role: "Conception UX/UI (cours ArchInfoUX)"
-client: "HEIG-VD — cours ArchInfoUX"
+client: "HEIG-VD (cours ArchInfoUX)"
 featured: 0
 skills:
   - "UX/UI design"
@@ -31,11 +31,11 @@ Second projet du cours **ArchInfoUX** (HEIG-VD, Ingénierie des médias) : conce
 
 ## Une association née en 1947
 
-L'**Association des Amis des Musées de Pully (AMP)** a **plus de 70 ans** d'histoire : fondée en 1947 sous le nom d'« Association du Vieux Pully » pour préserver le patrimoine local, elle a accompagné la transformation d'une simple vitrine communale en institutions culturelles reconnues — le **Musée d'art**, l'**ArchéoLab** (dédié à la vie à l'époque romaine) et l'**Espace Ramuz**. Aujourd'hui, elle soutient les musées financièrement, logistiquement et par des projets fédérateurs comme le **concours annuel des jeunes artistes**. Le site devait porter cette histoire tout en restant tourné vers l'action.
+L'**Association des Amis des Musées de Pully (AMP)** a **plus de 70 ans** d'histoire : fondée en 1947 sous le nom d'« Association du Vieux Pully » pour préserver le patrimoine local, elle a accompagné la transformation d'une simple vitrine communale en institutions culturelles reconnues : le **Musée d'art**, l'**ArchéoLab** (dédié à la vie à l'époque romaine) et l'**Espace Ramuz**. Aujourd'hui, elle soutient les musées financièrement, logistiquement et par des projets fédérateurs comme le **concours annuel des jeunes artistes**. Le site devait porter cette histoire tout en restant tourné vers l'action.
 
 ## Servir plusieurs publics à la fois
 
-Le site s'adresse à des visiteurs très différents — celui qui cherche une information pratique, l'amateur d'art qui suit le concours, le soutien qui veut adhérer ou donner. L'**architecture de l'information** répond à chacun via cinq entrées claires (Accueil, Association, Concours, Musées, Contact).
+Le site s'adresse à des visiteurs très différents : celui qui cherche une information pratique, l'amateur d'art qui suit le concours, le soutien qui veut adhérer ou donner. L'**architecture de l'information** répond à chacun via cinq entrées claires (Accueil, Association, Concours, Musées, Contact).
 
 ### Les musées, en un coup d'œil
 
@@ -47,15 +47,15 @@ Cœur battant de l'association, le concours dédié aux **jeunes artistes** disp
 
 ### Soutenir l'association
 
-Enfin, un parcours de soutien limpide : **« Devenir Ami·e »** (adhésion et ses avantages — entrées gratuites, rencontres avec les artistes), le **don** (coordonnées bancaires mises en avant), la **newsletter** et le **contact** direct. Les documents officiels (comité, assemblées générales, statuts, kit de presse) restent accessibles pour la transparence.
+Enfin, un parcours de soutien limpide : **« Devenir Ami·e »** (adhésion et ses avantages : entrées gratuites, rencontres avec les artistes), le **don** (coordonnées bancaires mises en avant), la **newsletter** et le **contact** direct. Les documents officiels (comité, assemblées générales, statuts, kit de presse) restent accessibles pour la transparence.
 
 ## Mobile et desktop, une seule cohérence
 
-La maquette **mobile** privilégie un parcours vertical dense — l'essentiel (horaires, concours, adhésion) dès la page d'accueil — tandis que la déclinaison **desktop** exploite la largeur pour la galerie d'œuvres et la carte des musées. **Même hiérarchie, mêmes composants, deux mises en scène** : la cohérence responsive est ici un objectif à part entière.
+La maquette **mobile** privilégie un parcours vertical dense, avec l'essentiel (horaires, concours, adhésion) dès la page d'accueil, tandis que la déclinaison **desktop** exploite la largeur pour la galerie d'œuvres et la carte des musées. **Même hiérarchie, mêmes composants, deux mises en scène** : la cohérence responsive est ici un objectif à part entière.
 
 ## Ce que j'en retire
 
-Un projet ancré dans le réel, où il fallait concilier l'**histoire** d'une association septuagénaire, les **besoins pratiques** de ses publics et l'**énergie** de son concours — le tout dans une interface haute-fidélité qui tient aussi bien sur un écran de poche que sur un grand écran.
+Un projet ancré dans le réel, où il fallait concilier l'**histoire** d'une association septuagénaire, les **besoins pratiques** de ses publics et l'**énergie** de son concours, le tout dans une interface haute-fidélité qui tient aussi bien sur un écran de poche que sur un grand écran.
 
 ## Galerie
 

--- a/src/content/project/nuage.mdx
+++ b/src/content/project/nuage.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Assistant mise en scène sur Nuage — 1minute2court"
+title: "Assistant mise en scène sur Nuage (1minute2court)"
 pubDate: 2025-05-11
 intro: "Aux côtés du réalisateur Sébastien Gerner, j'ai assisté la mise en scène de Nuage, court-métrage présenté au concours 1minute2court."
 seoDescription: "Coulisses du court-métrage 'Nuage' de Sébastien Gerner. Mon expérience en tant qu'assistant sur ce projet cinématographique."

--- a/src/content/project/paternelle.mdx
+++ b/src/content/project/paternelle.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Communication 360° de La Paternelle — 8 000 spectateurs par édition"
+title: "Communication 360° de La Paternelle : 8 000 spectateurs par édition"
 pubDate: 2025-12-05
 intro: "Depuis 2019, je pilote la communication de La Paternelle : stratégie, affiche et déclinaisons, affichage cantonal, presse, réseaux sociaux et captation. Dernières éditions à guichets fermés au Théâtre de Beaulieu."
 seoDescription: "Étude de cas communication : La Paternelle (Lausanne). Stratégie 360°, affichage, presse, réseaux sociaux et captation pour 8 000 spectateurs par édition."
@@ -63,7 +63,7 @@ Le point d'orgue de la saison se joue au prestigieux **Théâtre de Beaulieu**.
 - **Budget de 300'000 CHF** à valoriser.
 - Une machinerie communicationnelle qui doit tourner à la perfection pour remplir la plus grande salle de Suisse romande.
 
-## Édition 2025 — Le Voyage du Petit Prince
+## Édition 2025 : Le Voyage du Petit Prince
 
 > "On ne voit bien qu'avec le cœur. L'essentiel est invisible pour les yeux."
 
@@ -78,7 +78,7 @@ Une édition record : plus de 8 000 spectateurs et des représentations jouées 
 
 <ImageGallery folder="Paternelle-2025" />
 
-## Édition 2024 — Le Magicien d'Oz
+## Édition 2024 : Le Magicien d'Oz
 
 Un univers coloré qui a enchanté petits et grands, avec plus de **8 000 billets vendus** en un temps record.
 

--- a/src/content/project/portfolio-kuasar.mdx
+++ b/src/content/project/portfolio-kuasar.mdx
@@ -30,7 +30,7 @@ metrics:
 
 import ImageGallery from "../../components/ui/ImageGallery.astro";
 
-Ce site est lui-même un projet de développement web à part entière : je l'ai conçu, développé et je l'exploite en continu. L'objectif était double — présenter mon travail, et démontrer concrètement ma façon de construire un produit web : performant, accessible, sécurisé et industrialisé.
+Ce site est lui-même un projet de développement web à part entière : je l'ai conçu, développé et je l'exploite en continu. L'objectif était double : présenter mon travail, et démontrer concrètement ma façon de construire un produit web : performant, accessible, sécurisé et industrialisé.
 
 ## Architecture & choix techniques
 
@@ -38,7 +38,7 @@ Le site est un **site statique généré (SSG)** avec **Astro 6** : zéro JavaSc
 
 Quelques choix structurants :
 
-- **Contenu en collections typées** : chaque projet est un fichier MDX validé par un schéma (zod) — titres, rôles, catégories et métadonnées SEO sont contrôlés au build.
+- **Contenu en collections typées** : chaque projet est un fichier MDX validé par un schéma (zod) : titres, rôles, catégories et métadonnées SEO sont contrôlés au build.
 - **Pipeline d'images** : conversion et redimensionnement automatiques en AVIF/WebP via Sharp, avec `srcset` responsive généré pour chaque carte et galerie.
 - **PWA** : manifest et service worker (vite-plugin-pwa) pour le mode hors-ligne et l'installation.
 - **Hébergement edge** : déploiement sur **Cloudflare Pages**, formulaire de contact servi par une Pages Function avec validation stricte, honeypot anti-spam et allowlist d'origines.

--- a/src/content/project/vide-dressing.mdx
+++ b/src/content/project/vide-dressing.mdx
@@ -1,15 +1,15 @@
 ---
-title: "Architecture de l'information — plateforme Vide dressing"
+title: "Architecture de l'information pour la plateforme Vide dressing"
 pubDate: 2023-10-27
 intro: "Concevoir une plateforme de seconde main pour financer un espace étudiant : structuration de l'information (LATCH), personas, parcours utilisateur, wireframes et maquette Figma inspirée du swipe. Un travail d'équipe mené à trois."
-seoDescription: "Étude de cas UX et architecture de l'information (HEIG-VD) : plateforme de vente de seconde main — LATCH, personas, user flows, wireframes et maquette Figma."
+seoDescription: "Étude de cas UX et architecture de l'information (HEIG-VD) : plateforme de vente de seconde main : LATCH, personas, user flows, wireframes et maquette Figma."
 tag: "ux design"
 author: "samuel"
 image: "../../assets/vide-dressing/maquette.avif"
 type: "general"
 category: "web"
 role: "Architecture de l'information & UX (en équipe)"
-client: "HEIG-VD — cours ArchInfoUX"
+client: "HEIG-VD (cours ArchInfoUX)"
 featured: 45
 skills:
   - "Architecture de l'information"
@@ -29,35 +29,35 @@ metrics:
 
 import ImageGallery from "../../components/ui/ImageGallery.astro";
 
-Le défi du cours **ArchInfoUX** (HEIG-VD, Ingénierie des médias) : financer la création d'un espace « chill-out » pour les étudiant·e·s de Saint-Roch en utilisant **uniquement les ressources disponibles dans la classe**. Notre réponse : concevoir une **plateforme de vente en ligne de vêtements et d'accessoires de seconde main** appartenant aux étudiant·e·s — où chaque achat finance concrètement le projet commun. Ce projet est avant tout un exercice d'**architecture de l'information** : structurer avant de dessiner.
+Le défi du cours **ArchInfoUX** (HEIG-VD, Ingénierie des médias) : financer la création d'un espace « chill-out » pour les étudiant·e·s de Saint-Roch en utilisant **uniquement les ressources disponibles dans la classe**. Notre réponse : concevoir une **plateforme de vente en ligne de vêtements et d'accessoires de seconde main** appartenant aux étudiant·e·s, où chaque achat finance concrètement le projet commun. Ce projet est avant tout un exercice d'**architecture de l'information** : structurer avant de dessiner.
 
 ## Deux personas pour cadrer les décisions
 
 Toute la conception a été guidée par deux profils opposés mais complémentaires.
 
-### Isabelle — « l'amie éco-shoppeuse »
+### Isabelle, « l'amie éco-shoppeuse »
 
-35 ans, conseillère en gestion de patrimoine, mère de deux enfants, habitant près de l'école. **Technophile** et adepte des applications de shopping, elle valorise la **durabilité et l'économie circulaire**. Ses attentes ont poussé vers une navigation intuitive, des **filtres** efficaces, des **descriptions détaillées de l'état** des articles, un **paiement sécurisé** — et une **barre de progression** qui rend visible l'impact de chaque achat sur le financement.
+35 ans, conseillère en gestion de patrimoine, mère de deux enfants, habitant près de l'école. **Technophile** et adepte des applications de shopping, elle valorise la **durabilité et l'économie circulaire**. Ses attentes ont poussé vers une navigation intuitive, des **filtres** efficaces, des **descriptions détaillées de l'état** des articles, un **paiement sécurisé** et une **barre de progression** qui rend visible l'impact de chaque achat sur le financement.
 
-### Laurent — « l'étudiant stylé »
+### Laurent, « l'étudiant stylé »
 
-24 ans, étudiant en lettres, budget limité mais goût affirmé, **éco-conscient** et actif sur Instagram. Il attend un **design moderne et épuré**, un **filtrage par gamme de prix**, de l'**interaction sociale** (partage, lien vers Instagram) et une **personnalisation** selon ses préférences — sans renoncer à contribuer à la cause.
+24 ans, étudiant en lettres, budget limité mais goût affirmé, **éco-conscient** et actif sur Instagram. Il attend un **design moderne et épuré**, un **filtrage par gamme de prix**, de l'**interaction sociale** (partage, lien vers Instagram) et une **personnalisation** selon ses préférences, sans renoncer à contribuer à la cause.
 
 ## Structurer l'information avant de dessiner
 
 ### Le champ d'information
 
-Nous avons d'abord défini, pour chaque article, son **champ d'information** : contenus (photo, description avec état, prix, taille) et **attributs** clés — catégorie, taille, genre, prix. Les articles ont été répartis en grandes familles (Bijoux & accessoires, Vêtements, Chaussures) puis en sous-catégories précises, avec un principe fort : la **taille est filtrée automatiquement** selon les préférences de l'utilisateur, et un **toggle** ajuste le genre affiché.
+Nous avons d'abord défini, pour chaque article, son **champ d'information** : contenus (photo, description avec état, prix, taille) et **attributs** clés : catégorie, taille, genre, prix. Les articles ont été répartis en grandes familles (Bijoux & accessoires, Vêtements, Chaussures) puis en sous-catégories précises, avec un principe fort : la **taille est filtrée automatiquement** selon les préférences de l'utilisateur, et un **toggle** ajuste le genre affiché.
 
 ### LATCH : choisir le bon axe de tri
 
-Nous avons passé l'information au crible de la méthode **LATCH** (Location, Alphabet, Time, Category, Hierarchy). Chaque axe a été évalué — la localisation, l'ordre alphabétique, l'ancienneté, la popularité auraient tous pu structurer le catalogue — avant de retenir la **catégorie** comme axe principal, le plus naturel pour une navigation vestimentaire, décliné en sous-catégories fines (« Hauts » → t-shirts, pulls, chemises…).
+Nous avons passé l'information au crible de la méthode **LATCH** (Location, Alphabet, Time, Category, Hierarchy). Chaque axe a été évalué (la localisation, l'ordre alphabétique, l'ancienneté, la popularité auraient tous pu structurer le catalogue) avant de retenir la **catégorie** comme axe principal, le plus naturel pour une navigation vestimentaire, décliné en sous-catégories fines (« Hauts » → t-shirts, pulls, chemises…).
 
 ### Ontologie, taxonomie & chorégraphie
 
-- **Ontologie** — définir le sens et les relations : chaque produit est un jeu d'attributs, les articles se relient par catégorie, et **chaque vente se rattache à l'objectif de financement**.
-- **Taxonomie** — trois catégories principales, leurs sous-catégories et leurs attributs, pour une classification logique et prévisible.
-- **Chorégraphie** — la façon dont on interagit avec l'information : navigation par **cartes façon Tinder**, filtre par catégorie, personnalisation initiale (taille + genre) et toggle de genre.
+- **Ontologie** : définir le sens et les relations. Chaque produit est un jeu d'attributs, les articles se relient par catégorie, et **chaque vente se rattache à l'objectif de financement**.
+- **Taxonomie** : trois catégories principales, leurs sous-catégories et leurs attributs, pour une classification logique et prévisible.
+- **Chorégraphie** : la façon dont on interagit avec l'information, via une navigation par **cartes façon Tinder**, un filtre par catégorie, une personnalisation initiale (taille + genre) et un toggle de genre.
 
 ### Le soin porté aux labels
 
@@ -77,7 +77,7 @@ Plutôt qu'un tri figé, la page d'accueil présente les articles de façon **al
 
 ### La personnalisation dès le premier lancement
 
-Dès l'ouverture, l'application demande **taille et genre** pour filtrer d'emblée le contenu pertinent — moins de bruit, plus de confort, et la flexibilité d'ajuster le genre à tout moment.
+Dès l'ouverture, l'application demande **taille et genre** pour filtrer d'emblée le contenu pertinent : moins de bruit, plus de confort, et la flexibilité d'ajuster le genre à tout moment.
 
 ### Le filtrage par catégorie, façon Tinder
 
@@ -85,11 +85,11 @@ Au-delà de la découverte aléatoire, un **filtrage par catégorie** sous forme
 
 ## De l'architecture aux wireframes
 
-Le parcours complet a été formalisé — **sitemap**, parcours souhaitables, orientation de l'utilisateur, task/user flows et **wireflow** — avant d'aboutir aux **wireframes** puis à une **maquette Figma** : une interface de découverte par **swipe**, aux teintes volontairement vintage pour évoquer l'esprit friperie sans sacrifier la lisibilité.
+Le parcours complet a été formalisé (**sitemap**, parcours souhaitables, orientation de l'utilisateur, task/user flows et **wireflow**) avant d'aboutir aux **wireframes** puis à une **maquette Figma** : une interface de découverte par **swipe**, aux teintes volontairement vintage pour évoquer l'esprit friperie sans sacrifier la lisibilité.
 
 ## Ce que j'en retire
 
-Vide dressing est l'exercice qui m'a appris à **structurer l'information avant de dessiner** : sans un champ d'information clair, une taxonomie assumée et des labels soignés, aucune interface n'est vraiment intuitive. C'est aussi un bel exemple de design **au service d'un objectif** — ici, transformer chaque achat en contribution visible à un projet collectif.
+Vide dressing est l'exercice qui m'a appris à **structurer l'information avant de dessiner** : sans un champ d'information clair, une taxonomie assumée et des labels soignés, aucune interface n'est vraiment intuitive. C'est aussi un bel exemple de design **au service d'un objectif** : transformer chaque achat en contribution visible à un projet collectif.
 
 Projet réalisé en équipe avec **Catherine Mauron** et **Nicolas Wunderle**.
 

--- a/src/content/project/visualdon-projet.mdx
+++ b/src/content/project/visualdon-projet.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Histoire des émissions de CO₂ — datavisualisation interactive"
+title: "Histoire des émissions de CO₂ : datavisualisation interactive"
 pubDate: 2026-01-28
 intro: "Une datavisualisation de l'empreinte carbone mondiale de 1750 à 2024 : un globe explorable, des classements dynamiques des plus gros émetteurs et une frise temporelle animée sur près de trois siècles. Interface bilingue, données officielles du Global Carbon Budget, mises à jour automatiquement."
 seoDescription: "Datavisualisation des émissions mondiales de CO₂ (1750–2024) : globe interactif, classements et frise temporelle. React, D3.js, Global Carbon Budget."
@@ -8,8 +8,8 @@ author: "samuel"
 image: "../../assets/visualdon/globe-monde.avif"
 type: "general"
 category: "web"
-role: "Datavisualisation — conception & développement"
-client: "HEIG-VD — cours VisualDon"
+role: "Datavisualisation : conception & développement"
+client: "HEIG-VD (cours VisualDon)"
 featured: 55
 skills:
   - "Datavisualisation"
@@ -31,15 +31,15 @@ metrics:
 
 import ImageGallery from "../../components/ui/ImageGallery.astro";
 
-**Histoire des Émissions de CO₂** est une datavisualisation interactive qui raconte près de trois siècles d'empreinte carbone mondiale — de 1750 à 2024 — en transformant des données climatiques complexes en une expérience visuelle claire et accessible. Un projet du cours **VisualDon** (HEIG-VD, Ingénierie des médias), déployé en production sur Cloudflare Pages.
+**Histoire des Émissions de CO₂** est une datavisualisation interactive qui raconte près de trois siècles d'empreinte carbone mondiale, de 1750 à 2024, en transformant des données climatiques complexes en une expérience visuelle claire et accessible. Un projet du cours **VisualDon** (HEIG-VD, Ingénierie des médias), déployé en production sur Cloudflare Pages.
 
 ## Le parti pris : rendre tangible l'invisible
 
-Les émissions de CO₂ sont un sujet abstrait et chargé de chiffres. Le pari du projet : en faire quelque chose que l'on **explore avec le doigt**. Un **globe interactif** (que l'on fait tourner et zoomer) colore chaque pays selon son niveau d'émissions, tandis qu'un classement des **dix plus gros émetteurs** se met à jour en temps réel — le tout piloté par une frise temporelle qui balaie 270 ans d'histoire.
+Les émissions de CO₂ sont un sujet abstrait et chargé de chiffres. Le pari du projet : en faire quelque chose que l'on **explore avec le doigt**. Un **globe interactif** (que l'on fait tourner et zoomer) colore chaque pays selon son niveau d'émissions, tandis qu'un classement des **dix plus gros émetteurs** se met à jour en temps réel, le tout piloté par une frise temporelle qui balaie 270 ans d'histoire.
 
 ## Voyager dans le temps
 
-Au cœur de l'expérience, une **frise temporelle animée** : un bouton lecture/pause déroule l'évolution année après année, et le globe comme les graphiques se recomposent en direct. On voit littéralement l'empreinte carbone se déplacer et s'intensifier à travers les continents et les époques — de la révolution industrielle à aujourd'hui.
+Au cœur de l'expérience, une **frise temporelle animée** : un bouton lecture/pause déroule l'évolution année après année, et le globe comme les graphiques se recomposent en direct. On voit littéralement l'empreinte carbone se déplacer et s'intensifier à travers les continents et les époques, de la révolution industrielle à aujourd'hui.
 
 ## Explorer par pays et par secteur
 
@@ -68,7 +68,7 @@ Côté technique, l'application est construite en **React 19** et **D3.js**, ave
 
 ## Ce que j'en retire
 
-Ce projet est un bel exercice de **narration par la donnée** : passer d'un CSV brut de centaines de milliers de lignes à une histoire que l'on comprend en quelques secondes de manipulation. Il m'a fait travailler autant la **rigueur du traitement de données** que le **soin de l'interaction** — les deux faces d'une bonne datavisualisation.
+Ce projet est un bel exercice de **narration par la donnée** : passer d'un CSV brut de centaines de milliers de lignes à une histoire que l'on comprend en quelques secondes de manipulation. Il m'a fait travailler autant la **rigueur du traitement de données** que le **soin de l'interaction** : les deux faces d'une bonne datavisualisation.
 
 ## Galerie
 

--- a/src/content/project/xxcent-sourire.mdx
+++ b/src/content/project/xxcent-sourire.mdx
@@ -1,15 +1,16 @@
 ---
-title: "Photographe de plateau — Sourire d'un pleur, clip de Symbiony"
+title: "Assistant caméra & photographe de plateau sur Sourire d'un pleur (clip de Symbiony)"
 pubDate: 2024-07-17
-intro: "Sur ce clip tout en délicatesse, j'ai capté l'intimité du tournage en photographie de plateau et épaulé l'équipe en tant qu'assistant."
-seoDescription: "Coulisses du clip 'Sourire d'un pleur' de Symbiony. Mon travail d'assistant et de photographe de plateau."
+intro: "Sur ce clip tout en délicatesse, j'étais assistant caméra ; j'ai aussi capté l'intimité du tournage comme photographe de plateau."
+seoDescription: "Coulisses du clip « Sourire d'un pleur » de Symbiony : mon travail d'assistant caméra et de photographe de plateau."
 tag: clip musical
 author: samuel
 image: "../../assets/symbiony.avif"
 type: video
 videoUrl: https://www.youtube.com/watch?v=uTiGczn8dCU
-category: "photo"
-role: "Photographe de plateau & assistant"
+category: "video"
+secondaryCategories: ["photo"]
+role: "Assistant caméra & photographe de plateau"
 client: "Symbiony"
 featured: 38
 ---
@@ -19,13 +20,13 @@ import { YouTube } from "astro-embed";
 
 Le titre _Sourire d'un pleur_ de Symbiony est une œuvre profondément touchante, caractérisée par une mélancolie douce et une grande délicatesse musicale. Mettre en image une telle sensibilité exigeait une direction artistique particulièrement fine, où chaque cadrage, chaque éclairage devait servir l'émotion de l'artiste.
 
+## Au plus près de la caméra
+
+Mon poste principal sur cette production était celui d'**assistant caméra**. Sur un clip aussi délicat, la précision technique est décisive : préparer et servir la caméra, gérer les optiques et anticiper les besoins du réalisateur pour préserver la fameuse « bulle » émotionnelle si chère aux artistes sur le plateau. Cette place au plus près de l'image a contribué à l'harmonie de travail nécessaire pour servir au mieux le propos du morceau.
+
 ## Dans l'intimité du tournage
 
-Mon rôle principal de **Photographe de Plateau** a consisté à capter cette atmosphère intimiste et fragile sans jamais la perturber. La photographie de plateau sur un clip émotionnel repose sur la discrétion et la patience : il s'agit d'attraper au vol une expression authentique, un regard perdu ou la tension d'un instant clé entre deux prises. Ces images produites ne racontent pas seulement la réalisation technique du clip, elles en prolongent narativement la poésie. Elles reflètent la sincérité absolue de l'interprétation de Symbiony et magnifient la beauté de la lumière tamisée choisie pour l'occasion.
-
-## Une assistance de tous les instants
-
-Par ailleurs, assumer la fonction complémentaire d'**Assistant** sur cette production m'a permis d'agir en véritable garant du confort de l'équipe technique et créative. Gérer le flux d'informations, ajuster discrètement un élément du décor ou anticiper les besoins du réalisateur sont autant d'actions indispensables pour préserver cette fameuse "bulle" émotionnelle si chère aux artistes sur le plateau. Au final, cette double casquette a contribué à créer une harmonie de travail nécessaire pour servir au mieux le propos du morceau.
+Comme **photographe de plateau**, j'ai capté cette atmosphère intimiste et fragile sans jamais la perturber. La photographie de plateau sur un clip émotionnel repose sur la discrétion et la patience : attraper au vol une expression authentique, un regard perdu ou la tension d'un instant clé entre deux prises. Ces images ne racontent pas seulement la réalisation technique du clip, elles en prolongent narrativement la poésie. Elles reflètent la sincérité absolue de l'interprétation de Symbiony et magnifient la beauté de la lumière tamisée choisie pour l'occasion.
 
 ---
 

--- a/src/content/project/youplantes.mdx
+++ b/src/content/project/youplantes.mdx
@@ -1,15 +1,15 @@
 ---
-title: "Stratégie & conception e-commerce — boutique YouPlantes"
+title: "Stratégie & conception e-commerce pour la boutique YouPlantes"
 pubDate: 2023-01-31
 intro: "Concevoir une boutique en ligne de plantes de A à Z : stratégie de marque, personas, benchmark, wireframes mobile-first, boutique WooCommerce, SEO, emailing, logistique écoresponsable, tarification et indicateurs de performance. Un travail d'équipe mené à trois."
-seoDescription: "Étude de cas e-commerce (HEIG-VD) : YouPlantes, boutique en ligne de plantes — stratégie, personas, WooCommerce, SEO, emailing Mailchimp et logistique."
+seoDescription: "Étude de cas e-commerce (HEIG-VD) : YouPlantes, boutique en ligne de plantes : stratégie, personas, WooCommerce, SEO, emailing Mailchimp et logistique."
 tag: "e-commerce"
 author: "samuel"
 image: "../../assets/youplantes/identite.avif"
 type: "general"
 category: "web"
 role: "Stratégie e-commerce & conception (en équipe)"
-client: "HEIG-VD — cours E-Commerce"
+client: "HEIG-VD (cours E-Commerce)"
 featured: 50
 skills:
   - "Stratégie e-commerce"
@@ -30,11 +30,11 @@ metrics:
 
 import ImageGallery from "../../components/ui/ImageGallery.astro";
 
-**YouPlantes** est un projet e-commerce complet mené dans le cadre du cours E-Commerce de la HEIG-VD (Ingénierie des médias) : imaginer, positionner et construire une boutique en ligne de plantes d'intérieur, **du plan stratégique jusqu'aux conditions générales de vente**. Un projet mené à trois, où j'ai touché à toute la chaîne — stratégie de marque, conception, intégration WooCommerce, SEO, analytics, logistique et cadre juridique.
+**YouPlantes** est un projet e-commerce complet mené dans le cadre du cours E-Commerce de la HEIG-VD (Ingénierie des médias) : imaginer, positionner et construire une boutique en ligne de plantes d'intérieur, **du plan stratégique jusqu'aux conditions générales de vente**. Un projet mené à trois, où j'ai touché à toute la chaîne : stratégie de marque, conception, intégration WooCommerce, SEO, analytics, logistique et cadre juridique.
 
 ## Le cadre et l'objectif
 
-L'exercice ne se limitait pas à monter une boutique : il fallait penser une **entreprise** de bout en bout. Nous avons donc défini une marque, YouPlantes, avec des **objectifs ambitieux et datés** — un processus 100 % écoresponsable, une communication inclusive, la **neutralité carbone à deux ans**, la certification **B Corporation** dès la première année, et un partenariat éthique (type TooGoodToGo) pour écouler les invendus végétaux. Quatre valeurs structurent l'ensemble : **écoresponsabilité, équité & inclusivité, tolérance et transparence**.
+L'exercice ne se limitait pas à monter une boutique : il fallait penser une **entreprise** de bout en bout. Nous avons donc défini une marque, YouPlantes, avec des **objectifs ambitieux et datés** : un processus 100 % écoresponsable, une communication inclusive, la **neutralité carbone à deux ans**, la certification **B Corporation** dès la première année, et un partenariat éthique (type TooGoodToGo) pour écouler les invendus végétaux. Quatre valeurs structurent l'ensemble : **écoresponsabilité, équité & inclusivité, tolérance et transparence**.
 
 ## Un positionnement de marque audacieux
 
@@ -44,14 +44,14 @@ Ce parti pris n'est pas gratuit : il sert une **stratégie SEO différenciante**
 
 ## Stratégie : cibles & personas
 
-La cible : les **18–35 ans de Suisse romande**, qui s'intéressent aux plantes d'intérieur pour eux-mêmes ou à offrir. À partir de là, nous avons construit des **personas** pour incarner ces profils et guider chaque arbitrage de conception — du ton éditorial aux fonctionnalités prioritaires, en passant par le choix des canaux d'acquisition.
+La cible : les **18–35 ans de Suisse romande**, qui s'intéressent aux plantes d'intérieur pour eux-mêmes ou à offrir. À partir de là, nous avons construit des **personas** pour incarner ces profils et guider chaque arbitrage de conception, du ton éditorial aux fonctionnalités prioritaires, en passant par le choix des canaux d'acquisition.
 
 ## Benchmark
 
 Deux concurrents ont servi de boussole, analysés sous l'angle UX et acquisition :
 
-- **GardenCenter** — un bon design, de belles images, des articles de blog-conseil, une carte de fidélité et des bons-cadeaux de 25 à 1 000 CHF… mais aucun programme de parrainage ni ciblage des jeunes (pas de TikTok, pas de YouTube).
-- **MyLubie** — très fort sur l'acquisition jeune (TikTok, YouTube Shorts, parrainage, forte interaction Instagram via quiz et FAQ)… mais une mécanique agressive qui **force l'abonnement newsletter** pour accéder aux guides.
+- **GardenCenter** : un bon design, de belles images, des articles de blog-conseil, une carte de fidélité et des bons-cadeaux de 25 à 1 000 CHF… mais aucun programme de parrainage ni ciblage des jeunes (pas de TikTok, pas de YouTube).
+- **MyLubie** : très fort sur l'acquisition jeune (TikTok, YouTube Shorts, parrainage, forte interaction Instagram via quiz et FAQ)… mais une mécanique agressive qui **force l'abonnement newsletter** pour accéder aux guides.
 
 La synthèse a orienté nos choix : combiner le **sérieux éditorial** du premier avec l'**énergie sociale** du second, sans reproduire leurs travers respectifs.
 
@@ -59,8 +59,8 @@ La synthèse a orienté nos choix : combiner le **sérieux éditorial** du premi
 
 Le catalogue a été pensé en deux familles complémentaires :
 
-- des **produits simples** — terre, billes d'argile, arrosoirs, tabliers, tabourets de jardinage, et des cartes-cadeaux en papier **garnies de graines** ;
-- des **kits** clés en main comme porte d'entrée à l'activité — kit débutant, kit bouture, ou kit adapté au **type de sol** d'une plante précise.
+- des **produits simples** : terre, billes d'argile, arrosoirs, tabliers, tabourets de jardinage, et des cartes-cadeaux en papier **garnies de graines** ;
+- des **kits** clés en main comme porte d'entrée à l'activité (kit débutant, kit bouture, ou kit adapté au **type de sol** d'une plante précise).
 
 Le tout complété par une sélection de **littérature spécialisée**, proposée en affiliation.
 
@@ -74,7 +74,7 @@ La plateforme repose sur **WooCommerce**. Le thème retenu n'intégrant pas de b
 
 ### Facebook & l'API Conversions de Meta
 
-La boutique est reliée à la suite **Meta Business**. Au-delà du catalogue Facebook, c'est surtout l'**API Conversions** qui nous intéressait : elle relie les visiteurs du site aux audiences Meta pour, selon Meta, « optimiser le ciblage publicitaire, réduire le coût par action et mesurer les résultats » — de quoi affiner les campagnes en fonction des acheteurs réels du site.
+La boutique est reliée à la suite **Meta Business**. Au-delà du catalogue Facebook, c'est surtout l'**API Conversions** qui nous intéressait : elle relie les visiteurs du site aux audiences Meta pour, selon Meta, « optimiser le ciblage publicitaire, réduire le coût par action et mesurer les résultats », de quoi affiner les campagnes en fonction des acheteurs réels du site.
 
 ### Service client via WhatsApp
 
@@ -82,7 +82,7 @@ Pour un SAV léger sans outil lourd, le plug-in **« Click To Chat »** ouvre Wh
 
 ### Emailing avec Mailchimp (et conformité RGPD)
 
-Les campagnes passent par **Mailchimp** (plug-in WooCommerce), avec suivi du **panier abandonné**. Un point de conformité a été repéré et corrigé : la case d'opt-in **précochée par défaut** — illégale au regard du RGPD — a été **décochée**. La newsletter a été intégrée au pied de page, avec un CSS retravaillé pour coller à l'identité de la marque.
+Les campagnes passent par **Mailchimp** (plug-in WooCommerce), avec suivi du **panier abandonné**. Un point de conformité a été repéré et corrigé : la case d'opt-in **précochée par défaut** (illégale au regard du RGPD) a été **décochée**. La newsletter a été intégrée au pied de page, avec un CSS retravaillé pour coller à l'identité de la marque.
 
 ### Canaux de vente complémentaires
 
@@ -91,11 +91,11 @@ Les campagnes passent par **Mailchimp** (plug-in WooCommerce), avec suivi du **p
 
 ## Des fiches produit pensées pour les plantes
 
-Au-delà des standards (galerie, titre, prix, description, sélecteur de quantité, ajout au panier), les fiches intègrent les **informations vitales d'une plante** : ensoleillement, humidité, arrosage, floraison, taille et **toxicité** — présentées de façon lisible, là où les sites concurrents les noient dans des tableaux indigestes. Deux pistes d'amélioration ont été documentées pour une future **PWA** : des **notifications push** de rappel d'arrosage, et la **reconnaissance photo** d'une plante renvoyant directement vers sa fiche produit.
+Au-delà des standards (galerie, titre, prix, description, sélecteur de quantité, ajout au panier), les fiches intègrent les **informations vitales d'une plante** : ensoleillement, humidité, arrosage, floraison, taille et **toxicité**, présentées de façon lisible, là où les sites concurrents les noient dans des tableaux indigestes. Deux pistes d'amélioration ont été documentées pour une future **PWA** : des **notifications push** de rappel d'arrosage, et la **reconnaissance photo** d'une plante renvoyant directement vers sa fiche produit.
 
 ## Logistique écoresponsable
 
-Le fournisseur retenu, **Emballages Ross SA** (entreprise suisse, partenaires locaux, emballages recyclés), colle aux valeurs de la marque. Les envois utilisent par défaut l'option **« Proclimat »** de La Poste. Pour maîtriser les coûts, les emballages — dimensionnés sur les plus gros articles vendus — sont commandés **par lots de 100**, un choix qui suppose d'atteindre un certain volume de ventes pour être rentabilisé.
+Le fournisseur retenu, **Emballages Ross SA** (entreprise suisse, partenaires locaux, emballages recyclés), colle aux valeurs de la marque. Les envois utilisent par défaut l'option **« Proclimat »** de La Poste. Pour maîtriser les coûts, les emballages, dimensionnés sur les plus gros articles vendus, sont commandés **par lots de 100**, un choix qui suppose d'atteindre un certain volume de ventes pour être rentabilisé.
 
 ## Prix, taxes & paiements
 
@@ -103,7 +103,7 @@ Le modèle économique a été chiffré précisément :
 
 - **Marge cible de 20 %** par produit pour garantir la pérennité de la boutique ;
 - **livraison offerte au-dessus de 100 CHF** de panier, tout en conservant une marge de 10–20 % et un minimum de 15 CHF par envoi ;
-- des **frais de port différenciés** — de ~2,65 CHF pour les billes d'argile et cartes-cadeaux, à 7 CHF pour les articles encombrants (tabourets, arrosoirs), jusqu'à 14,50 CHF pour une plante de moins de 2 kg (**envoi fragile assuré**) ; la livraison le jour même a été écartée (64 CHF, trop coûteuse et géographiquement limitée) ;
+- des **frais de port différenciés** : de ~2,65 CHF pour les billes d'argile et cartes-cadeaux, à 7 CHF pour les articles encombrants (tabourets, arrosoirs), jusqu'à 14,50 CHF pour une plante de moins de 2 kg (**envoi fragile assuré**) ; la livraison le jour même a été écartée (64 CHF, trop coûteuse et géographiquement limitée) ;
 - une **TVA suisse** correctement ventilée : **2,5 %** sur les plantes vivantes et semences, **7,7 %** sur le reste.
 
 Côté encaissement, trois moyens complémentaires : **PayPal** (testé en sandbox, commission de 3,4 % + 0,55 CHF documentée), **virement bancaire** (frais réduits mais délai de validation plus long) et **Twint**, partenaire de WooCommerce et gage de confiance local (licence ~99 CHF/an).
@@ -118,19 +118,19 @@ Le dossier détaille les **indicateurs à suivre** et **où** les trouver dans *
 - **tunnel d'achat** (à construire soi-même via _Explore_, GA4 n'offrant pas de rapport préfait) ;
 - **meilleures ventes** (_Monetisation → E-commerce purchases_).
 
-Nous avons aussi pointé les **limites de GA4** — pas d'envoi automatique de récapitulatif hebdomadaire par mail, information souvent « cachée » et création de rapports plus fastidieuse que sur l'ancienne Universal Analytics — et les contournements (rapports partagés, outils de dataviz).
+Nous avons aussi pointé les **limites de GA4** (pas d'envoi automatique de récapitulatif hebdomadaire par mail, information souvent « cachée » et création de rapports plus fastidieuse que sur l'ancienne Universal Analytics) et les contournements (rapports partagés, outils de dataviz).
 
 ## Écoresponsabilité & inclusivité
 
-Deux partis pris assumés et transverses : l'**écoresponsabilité** (envois Proclimat, emballages recyclés, production Printful européenne) et l'**inclusivité** — l'ensemble des contenus est rédigé en **écriture inclusive**, avec une réflexion documentée sur ses **impacts SEO** (arbitrages entre formes inclusives et volume de recherche).
+Deux partis pris assumés et transverses : l'**écoresponsabilité** (envois Proclimat, emballages recyclés, production Printful européenne) et l'**inclusivité** : l'ensemble des contenus est rédigé en **écriture inclusive**, avec une réflexion documentée sur ses **impacts SEO** (arbitrages entre formes inclusives et volume de recherche).
 
 ## Cadre juridique
 
-Le projet va jusqu'au bout de la logique « vraie boutique » : rédaction des **conditions générales de vente** (inspirées de CGV suisses romandes, gestion des **bons-cadeaux** — valeurs fixes, non cumulables, complétables par un autre moyen de paiement —, **livraison limitée à la Suisse**, droit suisse et for judiciaire à Lausanne) et d'une **politique de protection des données** (nature des données collectées, usage, cookies et Analytics, gestion des abus).
+Le projet va jusqu'au bout de la logique « vraie boutique » : rédaction des **conditions générales de vente** (inspirées de CGV suisses romandes, gestion des **bons-cadeaux** (valeurs fixes, non cumulables, complétables par un autre moyen de paiement), **livraison limitée à la Suisse**, droit suisse et for judiciaire à Lausanne) et d'une **politique de protection des données** (nature des données collectées, usage, cookies et Analytics, gestion des abus).
 
 ## Défis & enseignements
 
-La **prise en main de WooCommerce** — nouvelle pour l'équipe — a demandé du temps, tout comme l'ajout manuel d'un blog absent du thème et la ré-adaptation à la nouvelle interface de GA4. YouPlantes reste le projet qui m'a fait toucher **toute la largeur d'un lancement e-commerce** : de la stratégie de marque au calcul de la TVA, en passant par l'intégration technique, l'acquisition et le juridique. J'en retiens la valeur d'une conception **cohérente de bout en bout**, où chaque décision — un mode de livraison, une case à cocher, un taux de marge, un mot-clé — engage à la fois l'utilisateur, la loi et le modèle économique. Prochaine étape identifiée : déployer le catalogue sur le **Google Merchant Center** pour apparaître dans l'onglet Shopping.
+La **prise en main de WooCommerce**, nouvelle pour l'équipe, a demandé du temps, tout comme l'ajout manuel d'un blog absent du thème et la ré-adaptation à la nouvelle interface de GA4. YouPlantes reste le projet qui m'a fait toucher **toute la largeur d'un lancement e-commerce** : de la stratégie de marque au calcul de la TVA, en passant par l'intégration technique, l'acquisition et le juridique. J'en retiens la valeur d'une conception **cohérente de bout en bout**, où chaque décision (un mode de livraison, une case à cocher, un taux de marge, un mot-clé) engage à la fois l'utilisateur, la loi et le modèle économique. Prochaine étape identifiée : déployer le catalogue sur le **Google Merchant Center** pour apparaître dans l'onglet Shopping.
 
 Projet réalisé en équipe avec **Asia Picasso** et **Daniel Mendes Gonçalves**.
 

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -36,7 +36,6 @@
   --shadow-glass: 0 8px 32px 0 rgb(0 0 0 / 30%);
   --shadow-glow: 0 0 20px rgb(99 102 241 / 50%);
   --shadow-glow-accent: 0 0 20px rgb(244 63 94 / 50%);
-  --aspect-9-16: 9 / 16;
 }
 
 /* Keyframes */
@@ -107,7 +106,6 @@
   header,
   footer,
   .hero-buttons,
-  .hero-carousel,
   #lightbox,
   #back-to-top,
   .group.mode-switch-btn {
@@ -484,23 +482,6 @@
   opacity: 1;
 }
 
-.infinite-scroll {
-  display: flex;
-  width: max-content;
-  animation: scroll-infinite 30s linear infinite;
-  will-change: transform;
-}
-
-@keyframes scroll-infinite {
-  0% {
-    transform: translateX(0);
-  }
-
-  100% {
-    transform: translateX(-50%);
-  }
-}
-
 .text-shimmer {
   background: linear-gradient(
     100deg,
@@ -662,10 +643,6 @@
     transform: none;
   }
 
-  .infinite-scroll {
-    animation: none;
-  }
-
   .tilt-card:hover {
     transform: scale(1.02);
   }
@@ -759,10 +736,6 @@
   /* Animation Durations */
   .duration-4s {
     animation-duration: 4s;
-  }
-
-  .duration-120s {
-    animation-duration: 120s;
   }
 
   /* Masks */

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -18,7 +18,6 @@ interface Window {
   __baseInitHandler?: () => void;
   __heroInitHandler?: () => void;
   __animationObserver?: IntersectionObserver | null;
-  __carouselObserver?: IntersectionObserver | null;
   __animInitHandler?: () => void;
   __lightboxInstance?: { destroy: () => void } | null;
   __lightboxInitHandler?: () => void;

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -158,7 +158,7 @@ const t = translations[lang as keyof typeof translations] || translations.fr;
     }
 
     <!-- Prérendu via la Speculation Rules API géré par Astro (prefetch +
-         experimental.clientPrerender) — voir astro.config.mjs. -->
+         experimental.clientPrerender), voir astro.config.mjs. -->
     <style is:global>
       /* Manual Font Face Definitions */
       @font-face {

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -698,7 +698,7 @@ const t = translations[lang as keyof typeof translations] || translations.fr;
        * ⚡ Bolt: Global Background Animation Optimizer
        * Pauses infinite CSS animations (.floating, .floating-slow) when elements
        * are off-screen to save GPU memory and CPU cycles.
-       * ⚡ Bolt: Centralized .infinite-scroll (carousel) and .hero-gradient-vibrant to reuse a single observer instead of creating multiple instances across components.
+       * ⚡ Bolt: Centralized .hero-gradient-vibrant to reuse a single observer instead of creating multiple instances across components.
        */
       function initAnimationOptimizer() {
         // Disconnect previous observer
@@ -709,7 +709,7 @@ const t = translations[lang as keyof typeof translations] || translations.fr;
 
         // Select all floating elements
         const animatedElements = document.querySelectorAll(
-          ".floating, .floating-slow, .floating-delayed, .infinite-scroll, .hero-gradient-vibrant",
+          ".floating, .floating-slow, .floating-delayed, .hero-gradient-vibrant",
         );
 
         if (animatedElements.length === 0) return;

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -22,7 +22,7 @@ const services = [
   {
     title: "Création de contenu",
     description:
-      "Vidéo et photographie : clips, courts-métrages, reportages et photo de plateau. Sur un tournage comme en post-production, l'objectif est le même — des images fortes, au service de votre histoire.",
+      "Vidéo et photographie : clips, courts-métrages, reportages et photo de plateau. Sur un tournage comme en post-production, l'objectif est le même : des images fortes, au service de votre histoire.",
     icon: "mdi:movie-open",
     color: "text-purple-500",
     gradient: "from-purple-500/20 to-purple-600/10",
@@ -30,7 +30,7 @@ const services = [
   {
     title: "Développement web",
     description:
-      "Sites, applications et plateformes : des écosystèmes rapides, accessibles et sécurisés, conçus, développés et exploités de bout en bout — comme ce portfolio.",
+      "Sites, applications et plateformes : des écosystèmes rapides, accessibles et sécurisés, conçus, développés et exploités de bout en bout, comme ce portfolio.",
     icon: "mdi:code-tags",
     color: "text-blue-500",
     gradient: "from-blue-500/20 to-blue-600/10",
@@ -125,7 +125,7 @@ const faq = [
   {
     question: "Quels services propose Samuel Dulex ?",
     answer:
-      "Trois piliers : la création de contenu (vidéo et photographie — clips, courts-métrages, reportages, photo de plateau), le développement web (sites, applications et plateformes en Astro, Vue.js, Laravel, TypeScript) et la communication (stratégie, campagnes, relations presse et promotion d'événements).",
+      "Trois piliers : la création de contenu (vidéo et photographie : clips, courts-métrages, reportages, photo de plateau), le développement web (sites, applications et plateformes en Astro, Vue.js, Laravel, TypeScript) et la communication (stratégie, campagnes, relations presse et promotion d'événements).",
   },
   {
     question: "Où est basé Samuel Dulex ?",

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -84,7 +84,7 @@ const jsonLd = {
 
 <Base jsonLd={jsonLd}>
   <main>
-    <Hero projects={allProjects} />
+    <Hero />
     <ServicesPreview />
     {/* ⚡ Bolt: Lazy load below-the-fold images to prioritize Hero LCP */}
     <LatestPosts

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,7 +11,7 @@ import config from "../config.mjs";
 const allProjects = await getSortedProjects();
 
 // Sélection éditoriale équilibrée entre les piliers (vidéo, photo, web,
-// communication) plutôt que les 7 plus récents — qui étaient presque
+// communication) plutôt que les 7 plus récents, qui étaient presque
 // toujours des projets vidéo.
 const featuredSelection = selectFeaturedBalanced(allProjects, 7);
 

--- a/src/pages/project/[...page].astro
+++ b/src/pages/project/[...page].astro
@@ -43,7 +43,7 @@ const siteUrl = "https://portfolio.kuasar.xyz";
 const collectionJsonLd = {
   "@context": "https://schema.org",
   "@type": "CollectionPage",
-  name: "Projets — Samuel Dulex",
+  name: "Projets de Samuel Dulex",
   description:
     "Collection complète des réalisations de Samuel Dulex en production vidéo, photographie et développement web à Lausanne, Suisse romande.",
   url: siteUrl + "/project/",

--- a/src/pages/project/[slug].astro
+++ b/src/pages/project/[slug].astro
@@ -202,7 +202,7 @@ const jsonLd = {
       <p
         class="text-sm md:text-base font-outfit uppercase tracking-widest text-pacamara-accent font-bold mb-6 animate-fade-in opacity-0 delay-300"
       >
-        {entry.data.role}{entry.data.client && ` — ${entry.data.client}`}
+        {entry.data.role}{entry.data.client && ` · ${entry.data.client}`}
       </p>
       <h1
         class="font-pacamara-space font-bold text-5xl md:text-7xl lg:text-8xl mb-6 text-pacamara-dark dark:text-white animate-slide-up opacity-0 leading-tight tracking-tight drop-shadow-sm dark:drop-shadow-lg delay-400"

--- a/src/pages/project/categorie/[pillar].astro
+++ b/src/pages/project/categorie/[pillar].astro
@@ -29,7 +29,7 @@ export async function getStaticPaths() {
 
 const { pillar, projects, counts, totalCount } = Astro.props;
 
-const title = `${pillar.label} — Réalisations`;
+const title = `Réalisations en ${pillar.label.toLowerCase()}`;
 const description = pillar.description;
 ---
 

--- a/src/utils/featured.ts
+++ b/src/utils/featured.ts
@@ -5,7 +5,7 @@ type Project = CollectionEntry<"project">;
 /**
  * Sélection éditoriale de la home : retient les projets mis en avant
  * (`featured` > 0) en alternant les piliers (`category`) pour qu'aucun
- * ne domine — le tri par date brute favorisait mécaniquement la vidéo.
+ * ne domine (le tri par date brute favorisait mécaniquement la vidéo).
  *
  * Les piliers sont visités par poids décroissant de leur meilleur projet,
  * un projet par pilier et par tour. Si la sélection est plus courte que

--- a/src/utils/pillars.ts
+++ b/src/utils/pillars.ts
@@ -29,7 +29,7 @@ export const PILLARS: Pillar[] = [
     label: "Développement web",
     categories: ["web"],
     description:
-      "Sites, applications et plateformes — conçus, développés et exploités.",
+      "Sites, applications et plateformes, conçus, développés et exploités.",
   },
   {
     slug: "communication",


### PR DESCRIPTION
## Description

Trois ajustements indépendants de la page d'accueil, de l'indexation et du contenu :

1. **Retrait du carrousel du hero.** Le carrousel affichait les mêmes projets `featured` (équilibrés par pilier) que la grille **« Projets sélectionnés »** juste en dessous : les 7 cartes de la grille étaient exactement les 7 premières du carrousel, dans le même ordre. C'était un **doublon de contenu**. Le hero redevient épuré (logo, titre, sous-titre, appels à l'action) et la grille bento reste l'unique vitrine projets de l'accueil.
2. **`lastmod` au sitemap.** Chaque URL porte désormais une balise `<lastmod>` (date de build) comme signal de fraîcheur pour Google Search Console.
3. **Ton éditorial et rôles corrigés.** Retrait de tous les tirets cadratins (—) du contenu et de l'UI, remplacés par une ponctuation naturelle au cas par cas. Correction du rôle sur 6 projets de clips musicaux où le poste principal était mal qualifié.

## Type of Change

- [x] 🎨 Style update (hero épuré, ton éditorial)
- [x] 🐛 Bug fix (rôle mal qualifié sur 6 projets)
- [x] ♻️ Code refactoring (suppression du carrousel et du CSS/JS mort associé)
- [x] 🔧 Configuration change (sitemap)
- [x] ⚡ Performance improvement (moins de DOM/JS sur la home ; SEO / indexation)

## Changes Made

**Hero de l'accueil**
- `src/components/features/home/Hero.astro` : suppression du carrousel (vignettes + script d'animation/défilement) ; le composant se réduit au logo (LCP), au titre, au sous-titre et aux deux CTA.
- `src/pages/index.astro` : `<Hero />` ne reçoit plus la liste des projets.
- Nettoyage du **CSS/JS mort** : `.infinite-scroll` + keyframes, `.hero-carousel` (styles d'impression), variable `--aspect-9-16`, utilitaire `.duration-120s` ; `.infinite-scroll` retiré de l'optimiseur d'animations global (`Base.astro`) et `__carouselObserver` de la déclaration de types.

**Sitemap**
- `astro.config.mjs` : hook `serialize(item)` sur `@astrojs/sitemap` valorisant `item.lastmod` avec une constante `BUILD_DATE` (`new Date().toISOString()`), calculée une fois par build.

**Ton éditorial**
- Retrait de tous les tirets cadratins (—) dans `src/content/project/*.mdx`, les pages, composants et `public/llms.txt` / `public/_redirects`, remplacés au cas par cas par des deux-points, virgules, parenthèses ou une reformulation légère selon le contexte de chaque phrase.

**Rôles corrigés**
- 5 clips musicaux (Cactus Heart, Proud Rebel, 478, Fly Away, Sourire d'un pleur) : le poste principal de Samuel était **assistant caméra**, la photographie de plateau n'étant qu'un second poste tenu en parallèle. `category` passe de `photo` à `video`, avec `photo` en catégorie secondaire ; rôle et intros réécrits en conséquence.
- 48H Genève 2024 (déjà en `video`, rôle électro/DIT/photographe de plateau) : ajout de `photo` en catégorie secondaire pour la même raison.

## Related Issues

N/A

## Testing

- [x] Tested locally
- [x] `pnpm run format:check` — OK ; `pnpm run lint` — 0 erreur
- [x] `pnpm run typecheck` — 0 erreur
- [x] Build succeeds (`pnpm run build`)
- [x] Tests unitaires — 127/127 pass
- [x] Tests e2e Playwright — 7/7 pass
- [x] Sitemap vérifié : les 32 URLs de `dist/sitemap-0.xml` portent un `<lastmod>`
- [x] Zéro tiret cadratin restant dans tout `dist/` (build final vérifié par recherche exhaustive)
- [x] Toutes les `seoDescription` revérifiées ≤ 160 caractères (limite zod) après reformulation
- [x] Contrôle visuel du hero et des badges vidéo/photo, desktop / mobile, thèmes clair et sombre

## Screenshots / Recordings

Hero épuré et centré : logo, les trois piliers (Création de contenu · Développement web · Communication), le pitch et les deux boutons. Plus de bande d'images en bas du hero, la section « Projets sélectionnés » enchaîne directement. Les 6 projets de clips corrigés affichent désormais les badges **Vidéo** et **Photo**.

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if needed)

## Additional Notes

Retirer le carrousel élimine aussi une bonne quantité de JavaScript côté client (gestion tactile, drag, observers) et allège le DOM de la page d'accueil, sans perte de contenu puisque la grille « Projets sélectionnés » montrait déjà ces projets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VsZmEuFFG9qNcyBynFNKz5