### PR TITLE
feat: conformité RGPD/nLPD du formulaire (page confidentialité + case de consentement)

### DIFF
--- a/e2e/site.spec.ts
+++ b/e2e/site.spec.ts
@@ -63,6 +63,50 @@ test.describe("Samuel Dulex Portfolio - E2E Tests", () => {
     await expect(page.locator("#name")).toHaveAttribute("aria-invalid", "true");
   });
 
+  test("contact form requires consent before submitting", async ({ page }) => {
+    await page.goto("/about/");
+
+    const contactForm = page.locator("#contact-form");
+    await contactForm.scrollIntoViewIfNeeded();
+
+    // Fill all fields but leave the consent checkbox unchecked.
+    await page.locator("#name").fill("Jean Test");
+    await page.locator("#email").fill("jean@example.com");
+    await page
+      .locator("#message")
+      .fill("Bonjour, ceci est un message de test suffisamment long.");
+
+    await contactForm.locator('button[type="submit"]').click();
+
+    // Submission is blocked and the consent field is flagged invalid.
+    await expect(page.locator("#form-error-message")).toBeVisible();
+    await expect(page.locator("#consent")).toHaveAttribute(
+      "aria-invalid",
+      "true",
+    );
+
+    // Checking the box clears the invalid state.
+    await page.locator("#consent").check();
+    await expect(page.locator("#consent")).not.toHaveAttribute(
+      "aria-invalid",
+      "true",
+    );
+  });
+
+  test("privacy policy page loads", async ({ page }) => {
+    await page.goto("/politique-de-confidentialite/");
+    await expect(page.locator("main h1").first()).toContainText(
+      /Politique de confidentialité/i,
+    );
+    // The contact form links to this page.
+    await page.goto("/about/");
+    await expect(
+      page
+        .locator("#contact-form")
+        .getByRole("link", { name: /politique de confidentialité/i }),
+    ).toHaveAttribute("href", "/politique-de-confidentialite/");
+  });
+
   test("theme toggle should work", async ({ page }) => {
     await page.goto("/");
 

--- a/src/components/common/ContactForm.astro
+++ b/src/components/common/ContactForm.astro
@@ -214,6 +214,41 @@ import { Icon } from "astro-icon/components";
       </div>
     </div>
 
+    <!-- 🛡️ RGPD / nLPD: Consentement au traitement des données -->
+    <div class="form-group">
+      <label
+        for="consent"
+        class="flex items-start gap-3 text-sm text-pacamara-primary/80 dark:text-white/80 cursor-pointer select-none"
+      >
+        <input
+          type="checkbox"
+          name="consent"
+          id="consent"
+          required
+          aria-required="true"
+          aria-describedby="consent-hint"
+          class="consent-checkbox mt-0.5 h-5 w-5 shrink-0 rounded border-2 border-pacamara-secondary/30 bg-white dark:bg-pacamara-dark accent-pacamara-accent cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pacamara-accent focus-visible:ring-offset-2 dark:focus-visible:ring-offset-pacamara-dark"
+        />
+        <span>
+          J'accepte que mes données soient traitées pour répondre à ma demande,
+          conformément à la <a
+            href="/politique-de-confidentialite/"
+            class="text-pacamara-accent hover:text-pacamara-secondary underline underline-offset-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pacamara-accent rounded"
+            >politique de confidentialité</a
+          >.<span class="sr-only"> (obligatoire)</span><span
+            aria-hidden="true"
+            class="text-pacamara-accent"
+          >
+            *</span
+          >
+        </span>
+      </label>
+      <p id="consent-hint" class="sr-only">
+        Vous devez accepter la politique de confidentialité pour envoyer votre
+        message.
+      </p>
+    </div>
+
     <!-- Submit Button -->
     <button
       type="submit"
@@ -403,6 +438,7 @@ import { Icon } from "astro-icon/components";
     private messageInput!: HTMLTextAreaElement;
     private messageCounter!: HTMLElement;
     private messageCounterSr!: HTMLElement;
+    private consentInput!: HTMLInputElement;
 
     private maxMessageLength: number = 5000;
     private resizeRaf: number | null = null;
@@ -450,6 +486,9 @@ import { Icon } from "astro-icon/components";
       this.messageCounterSr = document.getElementById(
         "message-counter-sr",
       ) as HTMLElement;
+      this.consentInput = this.form.querySelector(
+        'input[name="consent"]',
+      ) as HTMLInputElement;
 
       if (this.messageInput && this.messageCounter) {
         const maxLength = this.messageInput.getAttribute("maxlength") || "5000";
@@ -524,7 +563,8 @@ import { Icon } from "astro-icon/components";
       if (
         this.nameInput?.value.trim().length >= 2 &&
         isValidEmail(this.emailInput?.value || "") &&
-        this.messageInput?.value.trim().length >= 10
+        this.messageInput?.value.trim().length >= 10 &&
+        (!this.consentInput || this.consentInput.checked)
       ) {
         this.errorMessage?.classList.add("hidden");
       }
@@ -631,6 +671,15 @@ import { Icon } from "astro-icon/components";
             currentDesc.replace("form-error-message", "").trim(),
           );
         }
+        if (this.consentInput) {
+          this.consentInput.removeAttribute("aria-invalid");
+          const currentDesc =
+            this.consentInput.getAttribute("aria-describedby") || "";
+          this.consentInput.setAttribute(
+            "aria-describedby",
+            currentDesc.replace("form-error-message", "").trim(),
+          );
+        }
         (this.form.querySelector("input") as HTMLInputElement)?.focus();
       });
 
@@ -683,6 +732,22 @@ import { Icon } from "astro-icon/components";
           const currentDesc =
             this.emailInput.getAttribute("aria-describedby") || "";
           this.emailInput.setAttribute(
+            "aria-describedby",
+            currentDesc.replace("form-error-message", "").trim(),
+          );
+          this.hideErrorIfFormIsValid();
+        }
+      });
+
+      this.consentInput?.addEventListener("change", () => {
+        if (
+          this.consentInput.checked &&
+          this.consentInput.hasAttribute("aria-invalid")
+        ) {
+          this.consentInput.removeAttribute("aria-invalid");
+          const currentDesc =
+            this.consentInput.getAttribute("aria-describedby") || "";
+          this.consentInput.setAttribute(
             "aria-describedby",
             currentDesc.replace("form-error-message", "").trim(),
           );
@@ -759,6 +824,25 @@ import { Icon } from "astro-icon/components";
           this.showError(
             "Veuillez entrer un message d'au moins 10 caractères.",
             this.messageInput,
+          );
+          return;
+        }
+
+        if (this.consentInput && !this.consentInput.checked) {
+          this.consentInput.setAttribute("aria-invalid", "true");
+          const currentDesc =
+            this.consentInput.getAttribute("aria-describedby") || "";
+          if (!currentDesc.includes("form-error-message")) {
+            this.consentInput.setAttribute(
+              "aria-describedby",
+              currentDesc
+                ? `${currentDesc} form-error-message`
+                : "form-error-message",
+            );
+          }
+          this.showError(
+            "Veuillez accepter la politique de confidentialité pour envoyer votre message.",
+            this.consentInput,
           );
           return;
         }

--- a/src/components/common/Footer.astro
+++ b/src/components/common/Footer.astro
@@ -80,6 +80,13 @@ import { Icon } from "astro-icon/components";
               >Contact</a
             >
           </li>
+          <li>
+            <a
+              href="/politique-de-confidentialite/"
+              class="text-pacamara-primary/70 dark:text-white/70 hover:text-pacamara-accent focus-visible:text-pacamara-accent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pacamara-accent rounded"
+              >Confidentialité</a
+            >
+          </li>
         </ul>
       </nav>
     </div>

--- a/src/pages/politique-de-confidentialite.astro
+++ b/src/pages/politique-de-confidentialite.astro
@@ -1,0 +1,154 @@
+---
+import Base from "../layouts/Base.astro";
+import config from "../config.mjs";
+
+const title = "Politique de confidentialité";
+const description =
+  "Comment sont collectées, utilisées et protégées vos données lorsque vous me contactez via ce site. Responsable, finalités, sous-traitants, durée de conservation et vos droits.";
+
+// Dernière révision de cette politique (à mettre à jour en cas de changement réel).
+const lastUpdated = "Juillet 2026";
+---
+
+<Base postData={{ data: { title, description } }}>
+  <section class="container mx-auto max-w-3xl px-7 pt-16 pb-20">
+    <header class="mb-10">
+      <h1
+        class="font-pacamara-space font-bold text-4xl md:text-5xl mb-4 text-pacamara-dark dark:text-white"
+      >
+        Politique de confidentialité
+      </h1>
+      <p
+        class="text-sm text-pacamara-primary/60 dark:text-white/60 font-outfit"
+      >
+        Dernière mise à jour : {lastUpdated}
+      </p>
+    </header>
+
+    <article
+      class="prose max-w-none
+        prose-headings:font-pacamara-space prose-headings:font-bold prose-headings:text-pacamara-dark dark:prose-headings:text-white
+        prose-p:text-pacamara-primary/80 dark:prose-p:text-white/80 prose-p:font-outfit prose-p:leading-relaxed
+        prose-li:text-pacamara-primary/80 dark:prose-li:text-white/80 prose-li:font-outfit
+        prose-strong:text-pacamara-dark dark:prose-strong:text-white
+        prose-a:text-pacamara-accent hover:prose-a:text-pacamara-secondary prose-a:transition-colors"
+    >
+      <p>
+        Cette politique explique quelles données personnelles je collecte
+        lorsque vous utilisez ce site, en particulier son formulaire de contact,
+        pourquoi je les traite, avec qui elles sont partagées et quels sont vos
+        droits. Elle s'applique dans le respect de la Loi fédérale suisse sur la
+        protection des données (nLPD) et, pour les personnes concernées dans
+        l'Union européenne, du Règlement général sur la protection des données
+        (RGPD).
+      </p>
+
+      <h2>Responsable du traitement</h2>
+      <p>
+        Le responsable du traitement de vos données est <strong
+          >Samuel Dulex</strong
+        >, basé à Lausanne ({config.postalCode}), Suisse. Pour toute question
+        relative à vos données, vous pouvez me contacter à l'adresse{" "}
+        <a href={`mailto:${config.email}`}>{config.email}</a>.
+      </p>
+
+      <h2>Quelles données je collecte</h2>
+      <p>
+        Je ne collecte que les données que vous me transmettez volontairement
+        via le <strong>formulaire de contact</strong> :
+      </p>
+      <ul>
+        <li><strong>votre nom</strong> ;</li>
+        <li><strong>votre adresse e-mail</strong> ;</li>
+        <li><strong>le contenu de votre message</strong>.</li>
+      </ul>
+      <p>
+        Lors de l'envoi, mon prestataire de formulaire (voir plus bas) peut
+        aussi enregistrer des <strong>métadonnées techniques</strong> telles que votre
+        adresse IP, l'horodatage de l'envoi et la page d'origine, à des fins de sécurité
+        et de lutte contre le spam.
+      </p>
+
+      <h2>Pourquoi je traite ces données</h2>
+      <p>Vos données servent uniquement à :</p>
+      <ul>
+        <li>
+          <strong>répondre à votre demande</strong> et échanger avec vous à son sujet
+          ;
+        </li>
+        <li>
+          <strong>prévenir les abus</strong> (spam, envois automatisés) et assurer
+          la sécurité du site.
+        </li>
+      </ul>
+      <p>
+        La base légale de ce traitement est votre <strong>consentement</strong>
+        (la case que vous cochez avant l'envoi) ainsi que mon <strong
+          >intérêt légitime</strong
+        > à répondre aux personnes qui me sollicitent. Je n'utilise jamais ces données
+        pour de la prospection non sollicitée et je ne les revends pas.
+      </p>
+
+      <h2>Sous-traitant et transfert de données</h2>
+      <p>
+        L'acheminement des messages du formulaire est assuré par <strong
+          >Web3Forms</strong
+        > (exploité par Web3Creative), qui agit comme sous-traitant : il reçoit, valide,
+        stocke temporairement et me transmet vos soumissions par e-mail. Ce traitement
+        est encadré par un <strong>contrat de sous-traitance (DPA)</strong>.
+      </p>
+      <p>
+        Web3Forms opère depuis l'Inde et vos données peuvent donc être <strong
+          >transférées et traitées hors de Suisse et de l'Union européenne</strong
+        >. Ce transfert est encadré par les <strong
+          >Clauses Contractuelles Types</strong
+        > (Standard Contractual Clauses) prévues à cet effet, qui garantissent un
+        niveau de protection approprié.
+      </p>
+
+      <h2>Hébergement et mesure d'audience</h2>
+      <p>
+        Le site est hébergé sur <strong>Cloudflare Pages</strong>. La
+        fréquentation est mesurée avec <strong>Cloudflare Web Analytics</strong
+        >, un outil respectueux de la vie privée qui <strong
+          >n'utilise pas de cookies</strong
+        > et ne cherche pas à vous identifier ni à vous suivre entre les sites. Ce
+        site n'utilise donc pas de cookies publicitaires ni de traceurs tiers.
+      </p>
+
+      <h2>Durée de conservation</h2>
+      <p>
+        Je conserve le contenu de nos échanges le temps nécessaire au traitement
+        de votre demande et à un éventuel suivi. Côté prestataire, les
+        soumissions stockées par Web3Forms ont une durée de vie maximale de
+        <strong>trois ans</strong>, après quoi elles sont supprimées.
+      </p>
+
+      <h2>Vos droits</h2>
+      <p>
+        Conformément à la nLPD et au RGPD, vous disposez d'un droit d'<strong
+          >accès</strong
+        >, de <strong>rectification</strong>, d'<strong>effacement</strong>, de
+        <strong>limitation</strong> et d'<strong>opposition</strong> au traitement
+        de vos données, ainsi que d'un droit à la <strong>portabilité</strong>.
+        Vous pouvez à tout moment retirer votre consentement.
+      </p>
+      <p>
+        Pour exercer ces droits, écrivez-moi à <a
+          href={`mailto:${config.email}`}>{config.email}</a
+        >. Vous avez également le droit d'introduire une réclamation auprès
+        d'une autorité de contrôle : le <strong
+          >Préposé fédéral à la protection des données et à la transparence
+          (PFPDT)</strong
+        > en Suisse, ou l'autorité compétente de votre pays au sein de l'Union européenne.
+      </p>
+
+      <h2>Modifications</h2>
+      <p>
+        Cette politique peut être mise à jour pour refléter des évolutions du
+        site ou de la réglementation. La date de dernière mise à jour est
+        indiquée en haut de cette page.
+      </p>
+    </article>
+  </section>
+</Base>


### PR DESCRIPTION
## Description

Le formulaire de contact envoie des données personnelles à Web3Forms (un sous-traitant, avec transfert hors UE/Suisse), mais le site n'avait **ni page de confidentialité, ni recueil de consentement**. Le DPA de Web3Forms place explicitement la base légale et l'information des personnes à la charge du responsable du traitement (§2.4). Cette PR comble ce manque.

## Type of Change

- [x] ✨ New feature (conformité RGPD/nLPD)
- [x] 📝 Documentation update (page politique de confidentialité)
- [x] ✅ Test update

## Changes Made

- **Nouvelle page `src/pages/politique-de-confidentialite.astro`** : responsable du traitement, données collectées (nom, e-mail, message + métadonnées techniques), finalités et base légale (consentement + intérêt légitime), sous-traitant **Web3Forms/Web3Creative** avec transfert vers l'Inde encadré par les **Clauses Contractuelles Types**, hébergement Cloudflare et mesure d'audience **sans cookies**, rétention **3 ans**, droits des personnes et voie de réclamation (PFPDT).
- **Case à cocher obligatoire** dans `ContactForm.astro`, liée à cette page, avec validation JS : l'envoi est bloqué tant qu'elle n'est pas cochée (message d'erreur accessible, `aria-invalid`, effacement à la coche et au reset). Le consentement conditionne l'envoi côté client ; il n'est **pas** transmis à Web3Forms.
- **Lien « Confidentialité »** ajouté au footer.
- **2 tests e2e** : la case bloque l'envoi tant qu'elle n'est pas cochée ; la page de politique se charge et est bien liée depuis le formulaire.

## Related Issues

N/A

## Testing

- [x] `bun run check` (format + lint + typecheck) — 0 erreur
- [x] `bun test` — 127/127 pass
- [x] Tests e2e Playwright — **9/9 pass** (7 existants + 2 nouveaux)
- [x] `bun run build` — 34 pages (nouvelle page dans le sitemap)
- [x] Contrôle visuel du formulaire (case en clair/sombre) et de la page politique

## Screenshots / Recordings

Case de consentement intégrée sous le message, avant le bouton d'envoi, avec lien vers la nouvelle page. Page « Politique de confidentialité » en prose, cohérente avec le thème du site.

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if needed)

## Additional Notes

Ce n'est pas un avis juridique mais la bonne pratique standard pour un formulaire de contact suisse/UE avec sous-traitant hors zone. Points à valider côté Samuel : accepter le **DPA** dans le dashboard Web3Forms, et vérifier que la variable d'environnement `WEB3FORMS_ACCESS_KEY` est bien renseignée sur Cloudflare Pages (indépendant de cette PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VsZmEuFFG9qNcyBynFNKz5

---
_Generated by [Claude Code](https://claude.ai/code/session_01VsZmEuFFG9qNcyBynFNKz5)_