### PR TITLE
content: corriger les rôles de 4 courts-métrages + FAQ à la première personne

### DIFF
--- a/src/content/project/48h-geneve-2025.mdx
+++ b/src/content/project/48h-geneve-2025.mdx
@@ -1,15 +1,16 @@
 ---
 title: "Gaffer sur Gamines (court-métrage primé, 48H Genève 2025)"
 pubDate: 2025-10-18
-intro: "Chef électricien (gaffer) sur Gamines, court-métrage primé du 48H Film Project Genève 2025 : deux sœurs s'isolent dans une forêt d'automne, et le deuil partagé tourne au tribunal."
-seoDescription: "Gamines, court-métrage réalisé pour le 48h de Genève 2025. Gaffer sur ce projet primé."
+intro: "Chef électricien (gaffer) et photographe de plateau sur Gamines, court-métrage primé du 48H Film Project Genève 2025 : deux sœurs s'isolent dans une forêt d'automne, et le deuil partagé tourne au tribunal."
+seoDescription: "Gamines, court-métrage réalisé pour le 48h de Genève 2025. Gaffer et photographe de plateau sur ce projet primé."
 tag: "court-métrage"
 author: "samuel"
 image: "../../assets/48h-geneve-2025/_MG_9287.avif"
 type: "video"
 videoUrl: "https://youtu.be/JZd5PeqGi1s"
 category: "video"
-role: "Gaffer"
+secondaryCategories: ["photo"]
+role: "Gaffer & photographe de plateau"
 client: "48H Film Project Genève"
 featured: 82
 awards:
@@ -35,9 +36,11 @@ import prixImage from "../../assets/48h-geneve-2025/prix.avif";
 - **Cast** : Lisa Giudice et Claire Reyes
 - **Durée** : 5 minutes
 
-## Mon Rôle : Gaffer
+## Mon rôle
 
 J'ai occupé le poste de **Gaffer** (Chef Électricien) sur ce tournage, travaillant en étroite collaboration avec le Chef Opérateur François Verreyt pour sculpter la lumière de cette forêt d'automne.
+
+En parallèle, j'ai documenté le tournage comme **photographe de plateau** : les images de cette galerie sont issues de ce travail.
 
 ## Équipe Technique
 

--- a/src/content/project/48h-lausanne-2024.mdx
+++ b/src/content/project/48h-lausanne-2024.mdx
@@ -1,15 +1,16 @@
 ---
 title: "Électro & machiniste sur Après l'averse. (Meilleure Image, 48H Lausanne 2024)"
 pubDate: 2024-09-27
-intro: "Après l'averse. a reçu le Prix de la Meilleure Image au 48H Film Project Lausanne 2024. J'y ai tenu les postes d'électro, de machiniste et de DIT : 48 heures pour écrire, tourner et monter un film."
-seoDescription: "Découvrez les coulisses de 'Après l'averse.', court-métrage réalisé pour le 48H Film Project Lausanne 2024. Rôle : Electro, Machiniste et DIT."
+intro: "Après l'averse. a reçu le Prix de la Meilleure Image au 48H Film Project Lausanne 2024. J'y ai tenu les postes d'électro, de machiniste et de DIT, et documenté le tournage comme photographe de plateau : 48 heures pour écrire, tourner et monter un film."
+seoDescription: "Coulisses d'« Après l'averse. » (48H Film Project Lausanne 2024, Meilleure Image). Électro, machiniste, DIT et photographe de plateau."
 tag: court-métrage
 author: samuel
 image: ../../assets/48H-Lausanne-05.avif
 type: video
 videoUrl: https://youtu.be/yUMsNFqhfR8
 category: "video"
-role: "Électro, machiniste & DIT"
+secondaryCategories: ["photo"]
+role: "Électro, machiniste, DIT & photographe de plateau"
 client: "48H Film Project Lausanne"
 featured: 84
 awards:
@@ -52,6 +53,7 @@ Sur ce plateau, j'ai assuré plusieurs fonctions techniques pour garantir la qua
 
 - **Electro & Machiniste** : Gestion de la lumière et de la machinerie pour soutenir la vision du chef opérateur.
 - **DIT (Digital Imaging Technician)** : Gestion des flux de données et sécurisation des rushes.
+- **Photographe de plateau** : Captation des coulisses du tournage (les images de cette page).
 
 ### Casting
 

--- a/src/content/project/48h-vevey-2025.mdx
+++ b/src/content/project/48h-vevey-2025.mdx
@@ -1,8 +1,8 @@
 ---
-title: "Préproduction & logistique sur Bruit Blanc (VIFFF 2025)"
+title: "Assistant caméra, gaffer & photographe de plateau sur Bruit Blanc (VIFFF 2025)"
 pubDate: 2025-09-27
-intro: "Pour le concours Tournez court ! du VIFFF (Vevey), j'ai assuré la préproduction et la logistique de Bruit Blanc : un court-métrage écrit, tourné et monté en 48 heures sur le thème de l'utopie."
-seoDescription: "Court-métrage réalisé pour le concours Tournez court ! du VIFFF 2025. Thème : Utopie."
+intro: "Sur Bruit Blanc, court-métrage écrit, tourné et monté en 48 heures pour le concours Tournez court ! du VIFFF (Vevey), j'étais assistant caméra et gaffer, et j'ai aussi documenté le tournage comme photographe de plateau."
+seoDescription: "Court-métrage 48h du concours Tournez court ! (VIFFF 2025) : assistant caméra, gaffer et photographe de plateau. Thème : Utopie."
 tag: "court-métrage"
 author: "samuel"
 image: "../../assets/48h-vevey/_MG_8907.avif"
@@ -12,7 +12,8 @@ gallery:
   - "../../assets/48h-vevey/_MG_8912.avif"
   - "../../assets/48h-vevey/_MG_8941.avif"
 category: "video"
-role: "Préproduction & logistique de tournage"
+secondaryCategories: ["photo"]
+role: "Assistant caméra, gaffer & photographe de plateau"
 client: "VIFFF (Tournez court !)"
 featured: 0
 ---
@@ -30,9 +31,11 @@ import ImageGallery from "../../components/ui/ImageGallery.astro";
 
 Le format 48h est l'un des exercices les plus intenses de la production cinématographique. De la réception du thème à la remise de la copie finale, chaque minute compte. L'écriture du scénario, le repérage des lieux, le tournage et le montage doivent s'enchaîner sans temps mort. C'est un véritable test d'endurance créative qui pousse chaque membre de l'équipe à donner le meilleur de lui-même sous pression.
 
-## Mon implication
+## Mon rôle
 
-Sur ce projet, j'ai contribué à la préproduction et à la logistique du tournage, en assurant la coordination technique et en participant activement à la résolution des contraintes de temps et de matériel. L'intégration de la contrainte du travelling dans la narration a représenté un défi technique stimulant qui a enrichi le langage visuel du film.
+Sur ce tournage, j'étais **assistant caméra** et **gaffer** : préparer et servir la caméra, gérer les optiques, installer et régler la lumière au rythme serré des 48 heures, pour que chaque plan soit techniquement prêt. L'intégration de la contrainte du travelling dans la narration a représenté un défi technique stimulant qui a enrichi le langage visuel du film.
+
+En parallèle, j'ai documenté le plateau comme **photographe de plateau** : les images de cette galerie sont issues de ce travail.
 
 Le film a été projeté le **jeudi 23 octobre 2025** au cinéma Rex 1 à Vevey, devant un public enthousiaste du festival.
 

--- a/src/content/project/nuage.mdx
+++ b/src/content/project/nuage.mdx
@@ -1,15 +1,15 @@
 ---
-title: "Assistant mise en scène sur Nuage (1minute2court)"
+title: "Assistant caméra & gaffer sur Nuage (1minute2court)"
 pubDate: 2025-05-11
-intro: "Aux côtés du réalisateur Sébastien Gerner, j'ai assisté la mise en scène de Nuage, court-métrage présenté au concours 1minute2court."
-seoDescription: "Coulisses du court-métrage 'Nuage' de Sébastien Gerner. Mon expérience en tant qu'assistant sur ce projet cinématographique."
+intro: "Aux côtés du réalisateur Sébastien Gerner, j'étais assistant caméra et gaffer sur Nuage, court-métrage présenté au concours 1minute2court."
+seoDescription: "Coulisses du court-métrage « Nuage » de Sébastien Gerner : mon travail d'assistant caméra et de gaffer sur ce projet cinématographique."
 tag: court-métrage
 author: samuel
 image: "../../assets/nuage.avif"
 type: video
 videoUrl: https://www.youtube.com/watch?v=FjOgvbwwIE4
 category: "video"
-role: "Assistant mise en scène"
+role: "Assistant caméra & gaffer"
 client: "Sébastien Gerner (1minute2court)"
 featured: 35
 ---
@@ -17,13 +17,13 @@ featured: 35
 import ImageGallery from "../../components/ui/ImageGallery.astro";
 import { YouTube } from "astro-embed";
 
-**Nuage** est un projet cinématographique porté par le réalisateur Sébastien Gerner, présenté dans le cadre du concours **1minute2court**. Participer à cette aventure en tant qu'assistant de mise en scène a été une opportunité unique d'observer et de soutenir un processus créatif exigeant, au plus près de la vision du réalisateur.
+**Nuage** est un projet cinématographique porté par le réalisateur Sébastien Gerner, présenté dans le cadre du concours **1minute2court**. Participer à cette aventure comme **assistant caméra** et **gaffer** a été une opportunité unique de servir un processus créatif exigeant, au plus près de la caméra et de la lumière.
 
 ## L'expérience du tournage
 
-Sur ce plateau, chaque détail comptait. Le format court-métrage impose une rigueur particulière : chaque seconde de film doit compter, chaque plan doit servir la narration. Mon rôle a consisté à faciliter le travail de la mise en scène et à assurer la fluidité des opérations techniques, depuis la préparation des décors jusqu'à la coordination des prises de vue.
+Sur ce plateau, chaque détail comptait. Le format court-métrage impose une rigueur particulière : chaque seconde de film doit compter, chaque plan doit servir la narration. Mon rôle a consisté à préparer et servir la caméra, à installer et régler la lumière (gaffer), et à assurer la fluidité des opérations techniques, prise après prise.
 
-Cette collaboration m'a permis de renforcer mes compétences en gestion de plateau et m'a offert une perspective précieuse sur la fabrication d'un film de A à Z. Travailler aux côtés d'un réalisateur aussi méticuleux que Sébastien Gerner, c'est comprendre l'importance de la préparation et de l'adaptabilité face aux imprévus d'un tournage.
+Cette collaboration m'a permis de renforcer mes compétences caméra et lumière et m'a offert une perspective précieuse sur la fabrication d'un film de A à Z. Travailler aux côtés d'un réalisateur aussi méticuleux que Sébastien Gerner, c'est comprendre l'importance de la préparation et de l'adaptabilité face aux imprévus d'un tournage.
 
 ## Un format exigeant
 

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -123,22 +123,22 @@ const jsonLd = {
 
 const faq = [
   {
-    question: "Quels services propose Samuel Dulex ?",
+    question: "Quels services est-ce que je propose ?",
     answer:
       "Trois piliers : la création de contenu (vidéo et photographie : clips, courts-métrages, reportages, photo de plateau), le développement web (sites, applications et plateformes en Astro, Vue.js, Laravel, TypeScript) et la communication (stratégie, campagnes, relations presse et promotion d'événements).",
   },
   {
-    question: "Où est basé Samuel Dulex ?",
+    question: "Où suis-je basé ?",
     answer:
       "À Lausanne (1004), dans le canton de Vaud, en Suisse romande. Contact : hello@kuasar.xyz.",
   },
   {
-    question: "Dans quelles régions Samuel Dulex intervient-il ?",
+    question: "Dans quelles régions est-ce que j'interviens ?",
     answer:
       "Dans toute la Suisse romande : Lausanne, Genève, Fribourg, Neuchâtel, Sion, Vevey, Montreux, Yverdon-les-Bains, Nyon et Morges. Déplacements possibles dans toute la Suisse et à l'international.",
   },
   {
-    question: "Quelles sont les compétences techniques de Samuel Dulex ?",
+    question: "Quelles sont mes compétences techniques ?",
     answer:
       "En développement web : Astro, Vue.js, React, Laravel, TypeScript, Tailwind CSS. En création visuelle : DaVinci Resolve, Adobe Lightroom, Figma, photographie et direction artistique. En communication : SEO, Google Ads, Meta Ads, email marketing et CRM.",
   },


### PR DESCRIPTION
## Description

Deux corrections de contenu demandées par Samuel :

1. **Rôles sur quatre courts-métrages 48H** : préciser les postes réellement tenus, avec ajout du badge Photo là où Samuel a pris les photos de plateau.
2. **FAQ de la page À propos** : passer les questions de la troisième à la première personne (elles parlaient de « Samuel Dulex », ce qui sonne étrange pour un portfolio solo).

## Type of Change

- [x] 🐛 Bug fix (rôles inexacts)
- [x] 📝 Documentation update (contenu / FAQ)

## Changes Made

**Rôles des courts-métrages**
- `48h-vevey-2025.mdx` (Bruit Blanc) : « préproduction & logistique » → **assistant caméra, gaffer & photographe de plateau** ; catégorie vidéo + **photo** en secondaire.
- `nuage.mdx` : « assistant mise en scène » → **assistant caméra & gaffer**.
- `48h-geneve-2025.mdx` (Gamines) : ajout de **photographe de plateau** au poste de gaffer ; vidéo + **photo**.
- `48h-lausanne-2024.mdx` (Après l'averse.) : ajout de **photographe de plateau** aux postes électro/machiniste/DIT ; vidéo + **photo**.
- Titres, intros, descriptions SEO et corps réécrits en conséquence.

**FAQ (`about.astro`)**
- Questions à la première personne, dans la section visible **et** les données structurées JSON-LD `FAQPage` : « Quels services est-ce que je propose ? », « Où suis-je basé ? », « Dans quelles régions est-ce que j'interviens ? », « Quelles sont mes compétences techniques ? ». Réponses inchangées.

## Related Issues

N/A

## Testing

- [x] `bun run check` (format + lint + typecheck) — 0 erreur
- [x] `bun test` — 127/127 pass
- [x] `bun run build` — OK ; badges Vidéo + Photo vérifiés sur les projets corrigés
- [x] Tests e2e Playwright — 9/9 pass
- [x] `seoDescription` des 4 projets revérifiées ≤ 160 caractères

## Screenshots / Recordings

Les 3 projets 48H concernés (Bruit Blanc, Gamines, Après l'averse.) affichent désormais les badges **Vidéo** et **Photo** ; la FAQ de la page À propos se lit à la première personne.

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VsZmEuFFG9qNcyBynFNKz5

---
_Generated by [Claude Code](https://claude.ai/code/session_01VsZmEuFFG9qNcyBynFNKz5)_