### PR TITLE
ci: permettre le déploiement après un merge automatique

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -25,7 +25,12 @@ jobs:
       - name: Enable auto-merge
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          # Un merge déclenché avec GITHUB_TOKEN ne déclenche aucun workflow
+          # (garde-fou anti-récursion de GitHub) : le push sur master passe
+          # inaperçu et le déploiement Cloudflare n'a jamais lieu. Renseigner
+          # le secret AUTOMERGE_TOKEN (PAT avec le scope contents:write) pour
+          # que le merge automatique déclenche bien Pipeline.
+          GH_TOKEN: ${{secrets.AUTOMERGE_TOKEN || secrets.GITHUB_TOKEN}}
         run: |
           for i in {1..3}; do
             gh pr merge --auto --squash "$PR_URL" && break || {

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -15,6 +15,10 @@ on:
       - ".gitignore"
       - ".editorconfig"
       - "LICENSE"
+  # Permet de relancer un déploiement à la main quand aucun push n'a été
+  # émis sur master (typiquement après un merge automatique signé par
+  # GITHUB_TOKEN, qui ne déclenche aucun workflow).
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -88,7 +92,9 @@ jobs:
   deploy:
     name: Build & Deploy
     needs: [test]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: |
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+      && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
## Description

Le contenu fusionné sur `master` n'arrive plus en ligne. La PR #1405 (rôles des courts-métrages + FAQ à la première personne) a bien été fusionnée dans `cd419c8`, mais le workflow `Pipeline` n'a jamais tourné pour ce commit : le dernier run sur `master` correspond à `683a29b` (#1404). Cloudflare Pages sert donc toujours le build précédent.

Cause : `automerge.yml` appelle `gh pr merge --auto` avec `GITHUB_TOKEN`. GitHub n'émet volontairement aucun événement de workflow pour un push signé par ce jeton (garde-fou anti-récursion), donc le push de fusion sur `master` passe inaperçu et le job `Build & Deploy` n'est jamais déclenché.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🏗️ Build or CI/CD update

## Changes Made

- `pipeline.yml` : ajout du déclencheur `workflow_dispatch`, pour pouvoir relancer un déploiement sans avoir à pousser un commit sur `master`.
- `pipeline.yml` : la condition du job `Build & Deploy` accepte désormais `workflow_dispatch` en plus de `push`, toujours restreinte à `refs/heads/master`.
- `automerge.yml` : le jeton utilisé devient `secrets.AUTOMERGE_TOKEN` quand il est défini, avec repli sur `GITHUB_TOKEN`. Un PAT rétablit le déclenchement normal de `Pipeline` après un merge automatique.

## Testing

- [x] Tested locally
- [x] Build succeeds (`bun run build`)

Vérifications faites en local :

- Syntaxe YAML des deux workflows validée, déclencheurs relus après parsing (`push`, `pull_request`, `workflow_dispatch`).
- Formatage Prettier conforme sur les deux fichiers.
- Build complet régénéré depuis un cache vide : la fiche Bruit Blanc contient bien le rôle « Assistant caméra, gaffer & photographe de plateau » et les badges Vidéo + Photo. Le contenu était donc correct sur `master`, seul le déploiement manquait.

## Additional Notes

Aucun changement applicatif : les modifications ne touchent que les workflows.

Pour rétablir un déploiement automatique durable, il faut créer le secret `AUTOMERGE_TOKEN` (jeton personnel avec le droit d'écriture sur le contenu). Sans ce secret, le comportement reste identique à aujourd'hui, mais `workflow_dispatch` permet au moins de relancer un déploiement à la demande.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VsZmEuFFG9qNcyBynFNKz5)_